### PR TITLE
FC-0057: implement notifications model and its unit tests

### DIFF
--- a/forum/models/notifications.py
+++ b/forum/models/notifications.py
@@ -1,0 +1,84 @@
+"""
+Notification Class for Mongo backend.
+"""
+
+from forum.models.base_model import MongoBaseModel
+
+
+class Notifications(MongoBaseModel):
+    """
+    Notifications class for cs_comments_service notification model
+    """
+
+    # TODO: there's no collection named as notifications in mongo db
+    # change the below collection name where notifications are being saved
+    def __init__(self, collection_name="notifications", client=None):
+        """
+        Initializes the Notifications class.
+
+        Args:
+            collection_name: The name of the MongoDB collection.
+            client: The MongoDB client.
+        """
+        super().__init__(collection_name, client)
+
+    def insert(self, **kwargs) -> str:
+        """
+        Inserts a new notification document into the database.
+
+        Args:
+            notification_type: The type of notification.
+            info: Additional information about the notification.
+            actor_id: The ID of the user who triggered the notification.
+            target_id: The new ID of the target object(e.g. ID of post, thread or comment
+                        on which user has liked or commented) of the notification.
+            receiver_ids: List of user IDs who should receive the notification.
+
+        Returns:
+            The ID of the inserted document.
+        """
+        notification_data = {
+            "notification_type": kwargs.get("notification_type"),
+            "info": kwargs.get("info"),
+            "receiver_ids": kwargs.get("receiver_ids", []),
+        }
+        if "actor_id" in kwargs:
+            notification_data["actor_id"] = kwargs["actor_id"]
+        if "target_id" in kwargs:
+            notification_data["target_id"] = kwargs["target_id"]
+        result = self.collection.insert_one(notification_data)
+        return str(result.inserted_id)
+
+    def update(self, _id: str, **kwargs) -> int:
+        """
+        Updates a notification document in the database based on the id.
+
+        Args:
+            _id: The ID of the notification.
+            notification_type: The new type of notification.
+            info: The new additional information about the notification.
+            actor_id: The new ID of the user who triggered the notification.
+            target_id: The new ID of the target object(e.g. ID of post, thread or comment
+                        on which user has liked or commented) of the notification.
+            receiver_ids: The new list of user IDs who should receive the notification.
+
+        Returns:
+            The number of documents modified.
+        """
+        update_data = {}
+        if "notification_type" in kwargs:
+            update_data["notification_type"] = kwargs["notification_type"]
+        if "info" in kwargs:
+            update_data["info"] = kwargs["info"]
+        if "actor_id" in kwargs:
+            update_data["actor_id"] = kwargs["actor_id"]
+        if "target_id" in kwargs:
+            update_data["target_id"] = kwargs["target_id"]
+        if "receiver_ids" in kwargs:
+            update_data["receiver_ids"] = kwargs["receiver_ids"]
+
+        result = self.collection.update_one(
+            {"_id": _id},
+            {"$set": update_data},
+        )
+        return result.modified_count

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import mongomock
 import pytest
 
+from forum.models.notifications import Notifications
 from forum.models.threads import CommentThread
 from forum.models.users import Users
 from forum.mongo import MongoBackend
@@ -21,6 +22,9 @@ def fixture_mock_mongo_backend():
     collections = {
         "contents": db["contents"],
         "users": db["users"],
+        "notifications": db["notifications"],
+        # TODO: there's no collection named as notifications in mongo db
+        # change the above collection name where notifications are being saved
     }
 
     mock_backend = MagicMock(spec=MongoBackend)
@@ -47,3 +51,9 @@ def fixture_users_model(patch_mongo_backend):
 def fixture_comment_thread_model(patch_mongo_backend):
     """Get CommentThread model with patched backend."""
     return CommentThread(client=patch_mongo_backend.contents)
+
+
+@pytest.fixture(name="notifications_model")
+def fixture_notifications_model(patch_mongo_backend):
+    """Get Notifications model with patched backend."""
+    return Notifications(client=patch_mongo_backend.notifications)

--- a/tests/test_models/test_notifications.py
+++ b/tests/test_models/test_notifications.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""
+Tests for the `Notifications` model.
+"""
+from bson import ObjectId
+
+
+def test_insert(notifications_model):
+    """Test insert a notification into MongoDB."""
+    notification_id = notifications_model.insert(
+        notification_type="test_type",
+        info={"key": "value"},
+        actor_id="actor1",
+        target_id="target1",
+        receiver_ids=["receiver1", "receiver2"],
+    )
+    assert notification_id is not None
+    notification_data = notifications_model.get(_id=ObjectId(notification_id))
+    assert notification_data is not None
+    assert notification_data["notification_type"] == "test_type"
+    assert notification_data["info"] == {"key": "value"}
+    assert notification_data["actor_id"] == "actor1"
+    assert notification_data["target_id"] == "target1"
+    assert notification_data["receiver_ids"] == ["receiver1", "receiver2"]
+
+
+def test_delete(notifications_model):
+    """Test delete a notification from MongoDB."""
+    notification_id = notifications_model.insert(
+        notification_type="test_type",
+        info={"key": "value"},
+        actor_id="actor1",
+        target_id="target1",
+        receiver_ids=["receiver1", "receiver2"],
+    )
+    result = notifications_model.delete(ObjectId(notification_id))
+    assert result == 1
+    notification_data = notifications_model.get(_id=ObjectId(notification_id))
+    assert notification_data is None
+
+
+def test_list(notifications_model):
+    """Test list all notifications from MongoDB."""
+    notifications_model.collection.insert_many(
+        [
+            {
+                "notification_type": "type1",
+                "info": {"key1": "value1"},
+                "actor_id": "actor1",
+                "target_id": "target1",
+                "receiver_ids": ["receiver1"],
+            },
+            {
+                "notification_type": "type2",
+                "info": {"key2": "value2"},
+                "actor_id": "actor2",
+                "target_id": "target2",
+                "receiver_ids": ["receiver2"],
+            },
+            {
+                "notification_type": "type3",
+                "info": {"key3": "value3"},
+                "actor_id": "actor3",
+                "target_id": "target3",
+                "receiver_ids": ["receiver3"],
+            },
+        ]
+    )
+    notifications_list = notifications_model.list()
+    assert len(list(notifications_list)) == 3
+    assert all(
+        notification["notification_type"].startswith("type")
+        for notification in notifications_list
+    )
+
+
+def test_update(notifications_model):
+    """Test update a notification in MongoDB."""
+    notification_id = notifications_model.insert(
+        notification_type="test_type",
+        info={"key": "value"},
+        actor_id="actor1",
+        target_id="target1",
+        receiver_ids=["receiver1", "receiver2"],
+    )
+
+    result = notifications_model.update(
+        _id=ObjectId(notification_id),
+        notification_type="updated_type",
+        info={"key": "new_value"},
+        actor_id="new_actor",
+        target_id="new_target",
+        receiver_ids=["new_receiver"],
+    )
+    assert result == 1
+    notification_data = notifications_model.get(_id=ObjectId(notification_id))
+    assert notification_data["notification_type"] == "updated_type"
+    assert notification_data["info"] == {"key": "new_value"}
+    assert notification_data["actor_id"] == "new_actor"
+    assert notification_data["target_id"] == "new_target"
+    assert notification_data["receiver_ids"] == ["new_receiver"]


### PR DESCRIPTION
- add notification model according to the current implementation
- add unit tests for notifications
- TODO for above implementation: there's no collection named as notifications in mongo db, change the collection name where notifications are being saved
- close #15 


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
