### PR TITLE
chore: get rid of type/pylint ignore statements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 """
 forum documentation build configuration file.
 

--- a/forum/models/base_model.py
+++ b/forum/models/base_model.py
@@ -2,7 +2,7 @@
 Database models for forum.
 """
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Any, Optional
 
 from bson import ObjectId
@@ -39,11 +39,6 @@ class MongoBaseModel(ABC):
         """Get a list of all documents filtered by kwargs"""
         return self._collection.find(kwargs)
 
-    @abstractmethod
-    def insert(self, *args: Any, **kwargs: Any) -> str:
-        """Insert a new document"""
-        raise NotImplementedError
-
     def delete(self, _id: str) -> int:
         """
         Deletes a document from the database based on the id.
@@ -56,8 +51,3 @@ class MongoBaseModel(ABC):
         """
         result = self._collection.delete_one({"_id": ObjectId(_id)})
         return result.deleted_count
-
-    @abstractmethod
-    def update(self, *args: Any, **kwargs: Any) -> int:
-        """Update a document by ID"""
-        raise NotImplementedError

--- a/forum/models/comments.py
+++ b/forum/models/comments.py
@@ -1,5 +1,3 @@
-# pylint: disable=arguments-differ
-
 """Comment Class for mongo backend."""
 
 from datetime import datetime
@@ -7,17 +5,17 @@ from typing import Any, Dict, List, Optional
 
 from bson import ObjectId
 
-from forum.models.contents import Contents
+from forum.models.contents import BaseContents
 
 
-class Comment(Contents):
+class Comment(BaseContents):
     """
     Comment class for cs_comments_service content model
     """
 
     content_type = "Comment"
 
-    def insert(  # type: ignore  # pylint: disable=arguments-renamed
+    def insert(
         self,
         body: str,
         course_id: str,
@@ -69,7 +67,7 @@ class Comment(Contents):
         result = self._collection.insert_one(comment_data)
         return str(result.inserted_id)
 
-    def update(  # type: ignore
+    def update(
         self,
         comment_id: str,
         body: Optional[str] = None,

--- a/forum/models/threads.py
+++ b/forum/models/threads.py
@@ -1,5 +1,3 @@
-# pylint: disable=arguments-differ
-
 """Content Class for mongo backend."""
 
 from datetime import datetime
@@ -7,17 +5,17 @@ from typing import Any, Dict, List, Optional
 
 from bson import ObjectId
 
-from forum.models.contents import Contents
+from forum.models.contents import BaseContents
 
 
-class CommentThread(Contents):
+class CommentThread(BaseContents):
     """
     CommentThread class for cs_comments_service content model
     """
 
     content_type = "CommentThread"
 
-    def insert(  # type: ignore
+    def insert(
         self,
         title: str,
         body: str,
@@ -87,7 +85,7 @@ class CommentThread(Contents):
         result = self._collection.insert_one(thread_data)
         return str(result.inserted_id)
 
-    def update(  # type: ignore
+    def update(
         self,
         thread_id: str,
         thread_type: Optional[str] = None,

--- a/forum/models/users.py
+++ b/forum/models/users.py
@@ -1,5 +1,3 @@
-# pylint: disable=arguments-differ
-
 """Users Class for mongo backend."""
 
 from typing import Any, Dict, List, Optional

--- a/forum/serializers/contents.py
+++ b/forum/serializers/contents.py
@@ -1,13 +1,13 @@
 """Serializer class for content collection."""
 
-from typing import Any, Dict
+from typing import Any
 
 from rest_framework import serializers
 
 from forum.serializers.votes import VotesSerializer, VoteSummarySerializer
 
 
-class EditHistorySerializer(serializers.Serializer):  # type: ignore
+class EditHistorySerializer(serializers.Serializer[dict[str, Any]]):
     """
     Serializer for handling edit history of a post or comment
 
@@ -23,16 +23,16 @@ class EditHistorySerializer(serializers.Serializer):  # type: ignore
     editor_username = serializers.CharField()
     created_at = serializers.DateTimeField()
 
-    def create(self, validated_data: Dict[str, Any]) -> Any:
+    def create(self, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError
 
-    def update(self, instance: Any, validated_data: Dict[str, Any]) -> Any:
+    def update(self, instance: Any, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError
 
 
-class ContentSerializer(serializers.Serializer[Dict[str, Any]]):
+class ContentSerializer(serializers.Serializer[dict[str, Any]]):
     """
     Serializer for the content data.
 
@@ -88,16 +88,16 @@ class ContentSerializer(serializers.Serializer[Dict[str, Any]]):
     updated_at = serializers.DateTimeField(allow_null=True)
     created_at = serializers.DateTimeField(allow_null=True)
 
-    def create(self, validated_data: Dict[str, Any]) -> Any:
+    def create(self, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError
 
-    def update(self, instance: Any, validated_data: Dict[str, Any]) -> Any:
+    def update(self, instance: Any, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError
 
 
-class UserContentSerializer(serializers.Serializer):  # type: ignore
+class UserContentSerializer(serializers.Serializer[dict[str, Any]]):
     """
     Serializer for handling the content of a post or comment.
 
@@ -137,10 +137,10 @@ class UserContentSerializer(serializers.Serializer):  # type: ignore
     closed = serializers.BooleanField(default=False)
     type = serializers.CharField()
 
-    def create(self, validated_data: Dict[str, Any]) -> Any:
+    def create(self, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError
 
-    def update(self, instance: Any, validated_data: Dict[str, Any]) -> Any:
+    def update(self, instance: Any, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError

--- a/forum/serializers/votes.py
+++ b/forum/serializers/votes.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 from rest_framework import serializers
 
 
-class VotesSerializer(serializers.Serializer):  # type: ignore
+class VotesSerializer(serializers.Serializer[dict[str, Any]]):
     """
     Serializer for votes data.
 
@@ -40,7 +40,7 @@ class VotesSerializer(serializers.Serializer):  # type: ignore
         raise NotImplementedError
 
 
-class VotesInputSerializer(serializers.Serializer):  # type: ignore
+class VotesInputSerializer(serializers.Serializer[dict[str, Any]]):
     """
     Serializer for handling votes on a content item.
 
@@ -61,7 +61,7 @@ class VotesInputSerializer(serializers.Serializer):  # type: ignore
         raise NotImplementedError
 
 
-class VoteSummarySerializer(serializers.Serializer):  # type: ignore
+class VoteSummarySerializer(serializers.Serializer[dict[str, Any]]):
     """
     Serializer for summarizing votes on a content item.
 

--- a/forum/settings/common.py
+++ b/forum/settings/common.py
@@ -2,8 +2,10 @@
 Common settings for forum app.
 """
 
+from typing import Any
 
-def plugin_settings(settings):  # type: ignore
+
+def plugin_settings(settings: Any) -> None:
     """
     Common settings for forum app
     Set these variables in the Tutor Config or lms.yml for local testing

--- a/forum/settings/production.py
+++ b/forum/settings/production.py
@@ -2,8 +2,10 @@
 Production settings for forum app.
 """
 
+from typing import Any
 
-def plugin_settings(settings):  # type: ignore
+
+def plugin_settings(settings: Any) -> None:
     """
     Production settings for forum app
     """

--- a/test_utils/client.py
+++ b/test_utils/client.py
@@ -1,0 +1,35 @@
+"""
+Client utility for testing.
+"""
+
+import json
+from typing import Any
+
+from django.test import Client
+
+
+class APIClient(Client):
+    """
+    Extends the Django test client to include a custom PUT method.
+
+    This client sends JSON data with the correct headers.
+    """
+
+    def put_json(self, path: str, data: Any, *args: Any, **kwargs: Any):  # type: ignore
+        """
+        Send a PUT request with JSON data.
+
+        Args:
+            path (str): The URL path to send the request to.
+            data (dict): The data to be sent in the request body.
+            **kwargs: Additional keyword arguments to be passed to the parent method.
+
+        Returns:
+            The response object from the request.
+        """
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "HTTP_X_API_KEY": "your_api_key",
+        }
+        return self.put(path, data=json.dumps(data), headers=headers, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,13 @@
 Init file for tests.
 """
 
-import json
-from typing import Any, Generator, Union
+from typing import Any
 
 import mongomock
 import pytest
-from django.http.response import HttpResponse
-from django.test import Client
 from pymongo import MongoClient
+
+from test_utils.client import APIClient
 
 
 @pytest.fixture(autouse=True)
@@ -23,37 +22,7 @@ def patch_default_mongo_database(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-class APIClient(Client):
-    """
-    Extends the Django test client to include a custom PUT method.
-
-    This client sends JSON data with the correct headers.
-    """
-
-    def put(  # type: ignore[override,no-untyped-def] # pylint: disable=arguments-differ
-        self, path: str, data: Any, **kwargs
-    ) -> Union[HttpResponse, Any]:
-        """
-        Send a PUT request with JSON data.
-
-        Args:
-            path (str): The URL path to send the request to.
-            data (dict): The data to be sent in the request body.
-            **kwargs: Additional keyword arguments to be passed to the parent method.
-
-        Returns:
-            The response object from the request.
-        """
-        headers = {
-            "accept": "application/json",
-            "content-type": "application/json",
-            "HTTP_X_API_KEY": "your_api_key",
-        }
-        return super().put(path, data=json.dumps(data), headers=headers, **kwargs)
-
-
 @pytest.fixture(name="api_client")
-def fixture_api_client() -> Generator[APIClient, Any, Any]:
+def fixture_api_client() -> APIClient:
     """Create an API client for testing."""
-    client = APIClient()
-    yield client
+    return APIClient()

--- a/tests/test_views/test_flags.py
+++ b/tests/test_views/test_flags.py
@@ -2,12 +2,11 @@
 
 from unittest.mock import Mock, patch
 
-from django.test import Client
-
 from forum.models import Contents, Users
+from test_utils.client import APIClient
 
 
-def test_comment_thread_api(api_client: Client) -> None:
+def test_comment_thread_api(api_client: APIClient) -> None:
     """
     Test the comment thread flag API.
 
@@ -27,7 +26,7 @@ def test_comment_thread_api(api_client: Client) -> None:
     mock_contents_class = Mock(return_value=Contents())
     with patch("forum.models.Users", new=mock_users_class):
         with patch("forum.models.Contents", new=mock_contents_class):
-            response = api_client.put(
+            response = api_client.put_json(
                 f"/api/v2/threads/{comment_thread_id}/abuse_flag",
                 data={"user_id": str(user_id)},
             )
@@ -35,7 +34,7 @@ def test_comment_thread_api(api_client: Client) -> None:
             comment_thread = response.json()
             assert comment_thread["abuse_flaggers"] == [str(user_id)]
 
-            response = api_client.put(
+            response = api_client.put_json(
                 path=f"/api/v2/threads/{comment_thread_id}/abuse_unflag",
                 data={"user_id": str(user_id)},
             )
@@ -45,7 +44,7 @@ def test_comment_thread_api(api_client: Client) -> None:
             assert comment["abuse_flaggers"] == []
 
 
-def test_comment_flag_api(api_client: Client) -> None:
+def test_comment_flag_api(api_client: APIClient) -> None:
     """
     Test the comment flag API.
 
@@ -65,7 +64,7 @@ def test_comment_flag_api(api_client: Client) -> None:
     mock_contents_class = Mock(return_value=Contents())
     with patch("forum.models.Users", new=mock_users_class):
         with patch("forum.models.Contents", new=mock_contents_class):
-            response = api_client.put(
+            response = api_client.put_json(
                 f"/api/v2/comments/{comment_id}/abuse_flag",
                 data={"user_id": str(user_id)},
             )
@@ -73,7 +72,7 @@ def test_comment_flag_api(api_client: Client) -> None:
             comment_thread = response.json()
             assert comment_thread["abuse_flaggers"] == [str(user_id)]
 
-            response = api_client.put(
+            response = api_client.put_json(
                 path=f"/api/v2/comments/{comment_id}/abuse_unflag",
                 data={"user_id": str(user_id)},
             )
@@ -82,7 +81,7 @@ def test_comment_flag_api(api_client: Client) -> None:
             assert comment is not None
             assert comment["abuse_flaggers"] == []
 
-            response = api_client.put(
+            response = api_client.put_json(
                 path=f"/api/v2/comments/{comment_id}/abuse_unflag",
                 data={"user_id": str(user_id)},
             )
@@ -92,7 +91,7 @@ def test_comment_flag_api(api_client: Client) -> None:
             assert comment["abuse_flaggers"] == []
 
 
-def test_comment_flag_api_invalid_data(api_client: Client) -> None:
+def test_comment_flag_api_invalid_data(api_client: APIClient) -> None:
     """
     Test the comment flag API with invalid data.
 
@@ -104,7 +103,7 @@ def test_comment_flag_api_invalid_data(api_client: Client) -> None:
     mock_contents_class = Mock(return_value=Contents())
     with patch("forum.models.Users", new=mock_users_class):
         with patch("forum.models.Contents", new=mock_contents_class):
-            response = api_client.put(
+            response = api_client.put_json(
                 path="/api/v2/comments/66ace22474ba69001e1440bd/abuse_flag",
                 data={"user_id": str(user_id)},
             )


### PR DESCRIPTION
1. Child model classes inherited the insert and update methods, but with a different signature. This violated the Liskov principle, which is explained here: https://stackoverflow.com/a/54359797/356528 To bypass this, we migrated most of the Content class to a separate base class, and insert/update methods are no longer inherited.

2. We removed type ignores in serializers, which were simply missing a generic type definition.

3. We also updated the APIClient, but we failed to properly type it, because we don't know how to use "_MonkeyPatchedWSGIResponse".

