### PR TITLE
refactor: rename mongodb config variables

### DIFF
--- a/forum/mongo.py
+++ b/forum/mongo.py
@@ -13,8 +13,8 @@ Database = PymongoDatabase[dict[str, Any]]
 
 
 def get_database(
-    host: str = settings.MONGO_HOST,
-    port: int = settings.MONGO_PORT,
+    host: str = settings.FORUM_MONGO_HOST,
+    port: int = settings.FORUM_MONGO_PORT,
     user: str = "",
     password: str = "",
     database: str = "cs_comments_service",

--- a/forum/settings/common.py
+++ b/forum/settings/common.py
@@ -11,8 +11,8 @@ def plugin_settings(settings: Any) -> None:
     Set these variables in the Tutor Config or lms.yml for local testing
     """
     settings.FORUM_PORT = "4567"
-    settings.MONGO_HOST = "mongodb"
-    settings.MONGO_PORT = 27017
+    settings.FORUM_MONGO_HOST = "mongodb"
+    settings.FORUM_MONGO_PORT = 27017
 
     settings.FORUM_ELASTICSEARCH_INDEX_NAMES = ["comment_threads", "comments"]
     settings.FORUM_MAX_DEEP_SEARCH_COMMENT_COUNT = 1000

--- a/forum/settings/production.py
+++ b/forum/settings/production.py
@@ -7,12 +7,15 @@ from typing import Any
 
 def plugin_settings(settings: Any) -> None:
     """
-    Production settings for forum app
+    Production settings for forum app.
     """
     settings.FORUM_PORT = settings.ENV_TOKENS.get("FORUM_PORT", settings.FORUM_PORT)
-    settings.MONGO_HOST = settings.ENV_TOKENS.get("MONGO_HOST", settings.MONGO_HOST)
-    settings.MONGO_PORT = settings.ENV_TOKENS.get("MONGO_PORT", settings.MONGO_PORT)
-
+    settings.FORUM_MONGO_HOST = settings.ENV_TOKENS.get(
+        "FORUM_MONGO_HOST", settings.FORUM_MONGO_HOST
+    )
+    settings.FORUM_MONGO_PORT = settings.ENV_TOKENS.get(
+        "FORUM_MONGO_PORT", settings.FORUM_MONGO_PORT
+    )
     settings.ELASTIC_SEARCH_CONFIG = settings.ENV_TOKENS.get(
         "ELASTIC_SEARCH_CONFIG", settings.ELASTIC_SEARCH_CONFIG
     )

--- a/test_settings.py
+++ b/test_settings.py
@@ -63,5 +63,5 @@ TEMPLATES = [
 ]
 
 FORUM_PORT = "4567"
-MONGO_HOST = "mongo-test-url"
-MONGO_PORT = 27017
+FORUM_MONGO_HOST = "mongo-test-url"
+FORUM_MONGO_PORT = 27017


### PR DESCRIPTION
Rename mongodb host and port settings to add prefix  to avoid ambiguity with openedx close# 045
