### PR TITLE
FC-0057: implement tests for comments APIs

### DIFF
--- a/forum/models/comments.py
+++ b/forum/models/comments.py
@@ -1,7 +1,7 @@
 """Comment Class for mongo backend."""
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from bson import ObjectId
 
@@ -17,7 +17,7 @@ class Comment(BaseContents):
     index_name = "comments"
     content_type = "Comment"
 
-    def override_query(self, query: Dict[str, Any]) -> Dict[str, Any]:
+    def override_query(self, query: dict[str, Any]) -> dict[str, Any]:
         query = {**query, "_type": self.content_type}
         return super().override_query(query)
 
@@ -32,8 +32,8 @@ class Comment(BaseContents):
         anonymous: bool = False,
         anonymous_to_peers: bool = False,
         depth: int = 0,
-        abuse_flaggers: Optional[List[str]] = None,
-        historical_abuse_flaggers: Optional[List[str]] = None,
+        abuse_flaggers: Optional[list[str]] = None,
+        historical_abuse_flaggers: Optional[list[str]] = None,
         visible: bool = True,
     ) -> str:
         """
@@ -48,8 +48,8 @@ class Comment(BaseContents):
             anonymous (bool, optional): Whether the comment is posted anonymously. Defaults to False.
             anonymous_to_peers (bool, optional): Whether the comment is anonymous to peers. Defaults to False.
             depth (int, optional): The depth of the comment in the thread hierarchy. Defaults to 0.
-            abuse_flaggers (Optional[List[str]], optional): Users who flagged the comment. Defaults to None.
-            historical_abuse_flaggers (Optional[List[str]], optional): Users historically flagged the comment.
+            abuse_flaggers (Optional[list[str]], optional): Users who flagged the comment. Defaults to None.
+            historical_abuse_flaggers (Optional[list[str]], optional): Users historically flagged the comment.
             visible (bool, optional): Whether the comment is visible. Defaults to True.
 
         Returns:
@@ -74,7 +74,7 @@ class Comment(BaseContents):
             "endorsed": False,
             "anonymous": anonymous,
             "anonymous_to_peers": anonymous_to_peers,
-            "parent_id": ObjectId(parent_id),
+            "parent_id": ObjectId(parent_id) if parent_id else None,
             "author_id": author_id,
             "comment_thread_id": ObjectId(comment_thread_id),
             "child_count": 0,
@@ -96,13 +96,13 @@ class Comment(BaseContents):
         anonymous: Optional[bool] = None,
         anonymous_to_peers: Optional[bool] = None,
         comment_thread_id: Optional[ObjectId] = None,
-        at_position_list: Optional[List[str]] = None,
+        at_position_list: Optional[list[str]] = None,
         visible: Optional[bool] = None,
         author_id: Optional[str] = None,
         author_username: Optional[str] = None,
-        votes: Optional[Dict[str, int]] = None,
-        abuse_flaggers: Optional[List[str]] = None,
-        historical_abuse_flaggers: Optional[List[str]] = None,
+        votes: Optional[dict[str, int]] = None,
+        abuse_flaggers: Optional[list[str]] = None,
+        historical_abuse_flaggers: Optional[list[str]] = None,
         endorsed: Optional[bool] = None,
         child_count: Optional[int] = None,
         depth: Optional[int] = None,
@@ -123,13 +123,13 @@ class Comment(BaseContents):
             anonymous (Optional[bool], optional): Whether the comment is posted anonymously.
             anonymous_to_peers (Optional[bool], optional): Whether the comment is anonymous to peers.
             comment_thread_id (Optional[ObjectId], optional): The ID of the parent comment thread.
-            at_position_list (Optional[List[str]], optional): A list of positions for @mentions.
+            at_position_list (Optional[list[str]], optional): A list of positions for @mentions.
             visible (Optional[bool], optional): Whether the comment is visible.
             author_id (Optional[str], optional): The ID of the author who created the comment.
             author_username (Optional[str], optional): The username of the author.
-            votes (Optional[Dict[str, int]], optional): The votes for the comment.
-            abuse_flaggers (Optional[List[str]], optional): A list of users who flagged the comment for abuse.
-            historical_abuse_flaggers (Optional[List[str]], optional): Users who historically flagged the comment.
+            votes (Optional[dict[str, int]], optional): The votes for the comment.
+            abuse_flaggers (Optional[list[str]], optional): A list of users who flagged the comment for abuse.
+            historical_abuse_flaggers (Optional[list[str]], optional): Users who historically flagged the comment.
             endorsed (Optional[bool], optional): Whether the comment is endorsed.
             child_count (Optional[int], optional): The number of child comments.
             depth (Optional[int], optional): The depth of the comment in the thread hierarchy.
@@ -155,7 +155,7 @@ class Comment(BaseContents):
             ("depth", depth),
             ("closed", closed),
         ]
-        update_data: Dict[str, Any] = {
+        update_data: dict[str, Any] = {
             field: value for field, value in fields if value is not None
         }
         if endorsed and endorsement_user_id:
@@ -163,6 +163,8 @@ class Comment(BaseContents):
                 "user_id": endorsement_user_id,
                 "time": datetime.now(),
             }
+        else:
+            update_data["endorsement"] = None
 
         if editing_user_id:
             edit_history = [] if edit_history is None else edit_history

--- a/forum/serializers/comment.py
+++ b/forum/serializers/comment.py
@@ -2,7 +2,7 @@
 Serializer for the comment data.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 from rest_framework import serializers
 
@@ -62,6 +62,12 @@ class UserCommentSerializer(UserContentSerializer):
             for field in exclude_fields:
                 self.fields.pop(field, None)
 
+    def to_representation(self, instance: Any) -> dict[str, Any]:
+        comment = super().to_representation(instance)
+        if comment["parent_id"] == "None":
+            comment["parent_id"] = None
+        return comment
+
     def get_sk(self, obj: dict[str, Any]) -> str:
         """Return sk field"""
         is_child = obj.get("parent_id")
@@ -72,10 +78,10 @@ class UserCommentSerializer(UserContentSerializer):
         else:
             return "{id}".format(id=obj.get("_id"))
 
-    def create(self, validated_data: Dict[str, Any]) -> Any:
+    def create(self, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError
 
-    def update(self, instance: Any, validated_data: Dict[str, Any]) -> Any:
+    def update(self, instance: Any, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError

--- a/forum/views/comments.py
+++ b/forum/views/comments.py
@@ -55,7 +55,7 @@ class CommentsAPIView(APIView):
         except ObjectDoesNotExist:
             return Response(
                 {"error": "Comment does not exist"},
-                status=status.HTTP_404_NOT_FOUND,
+                status=status.HTTP_400_BAD_REQUEST,
             )
         data = self._prepare_response(
             comment,
@@ -84,7 +84,7 @@ class CommentsAPIView(APIView):
         data = request.data
         fields_to_validate = ["body", "course_id", "user_id"]
         for field in fields_to_validate:
-            if field not in data:
+            if field not in data or not data[field]:
                 return Response(
                     f"{field} is missing.",
                     status=status.HTTP_400_BAD_REQUEST,
@@ -108,7 +108,7 @@ class CommentsAPIView(APIView):
                 )
         except ValidationError as error:
             return Response(
-                error,
+                error.detail,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -131,10 +131,10 @@ class CommentsAPIView(APIView):
         except ObjectDoesNotExist:
             return Response(
                 {"error": "Comment does not exist"},
-                status=status.HTTP_404_NOT_FOUND,
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
-        data = request.POST.dict()
+        data = request.data
         update_comment_data: dict[str, Any] = self._get_update_comment_data(data)
         update_comment_data["edit_history"] = comment.get("edit_history", [])
         update_comment_data["original_body"] = comment.get("body")
@@ -153,7 +153,7 @@ class CommentsAPIView(APIView):
                 )
         except ValidationError as error:
             return Response(
-                error,
+                error.detail,
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(data, status=status.HTTP_200_OK)
@@ -175,7 +175,7 @@ class CommentsAPIView(APIView):
         except ObjectDoesNotExist:
             return Response(
                 {"error": "Comment does not exist"},
-                status=status.HTTP_404_NOT_FOUND,
+                status=status.HTTP_400_BAD_REQUEST,
             )
         data = self._prepare_response(
             comment,

--- a/test_utils/client.py
+++ b/test_utils/client.py
@@ -10,18 +10,21 @@ from django.test import Client
 
 class APIClient(Client):
     """
-    Extends the Django test client to include a custom PUT method.
+    Extends the Django test client to include custom methods for sending requests.
 
     This client sends JSON data with the correct headers.
     """
 
-    def put_json(self, path: str, data: Any, *args: Any, **kwargs: Any):  # type: ignore
+    def send_request(
+        self, method: str, path: str, data: Any, *args: Any, **kwargs: Any
+    ) -> Any:
         """
-        Send a PUT request with JSON data.
+        Send a request with the specified HTTP method and JSON data.
 
         Args:
+            method (str): The HTTP method (e.g., 'GET', 'POST', 'PUT', 'DELETE').
             path (str): The URL path to send the request to.
-            data (dict): The data to be sent in the request body.
+            data (Optional[dict]): The data to be sent in the request body (if applicable).
             **kwargs: Additional keyword arguments to be passed to the parent method.
 
         Returns:
@@ -32,4 +35,31 @@ class APIClient(Client):
             "content-type": "application/json",
             "HTTP_X_API_KEY": "your_api_key",
         }
-        return self.put(path, data=json.dumps(data), headers=headers, **kwargs)
+        if method.lower() in ["post", "put"]:
+            data = json.dumps(data) if data else None
+
+        return self.generic(method, path, data, headers=headers, **kwargs)
+
+    def get_json(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        """
+        Send a GET request.
+        """
+        return self.send_request("GET", path, None, *args, **kwargs)
+
+    def post_json(self, path: str, data: Any, *args: Any, **kwargs: Any) -> Any:
+        """
+        Send a POST request with JSON data.
+        """
+        return self.send_request("POST", path, data, *args, **kwargs)
+
+    def put_json(self, path: str, data: Any, *args: Any, **kwargs: Any) -> Any:
+        """
+        Send a PUT request with JSON data.
+        """
+        return self.send_request("PUT", path, data, *args, **kwargs)
+
+    def delete_json(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        """
+        Send a DELETE request.
+        """
+        return self.send_request("DELETE", path, None, *args, **kwargs)

--- a/tests/test_views/test_comments.py
+++ b/tests/test_views/test_comments.py
@@ -1,0 +1,205 @@
+"""Test comments api endpoints."""
+
+from forum.models import Comment, CommentThread, Users
+from test_utils.client import APIClient
+
+
+def setup_models() -> tuple[str, str, str]:
+    """
+    Setup models.
+
+    This will create a user, thread and parent comment
+    for being used in comments api tests.
+    """
+
+    user_id = "1"
+    username = "user1"
+    course_id = "course-xyz"
+    Users().insert(user_id, username=username, email="email1")
+    comment_thread_id = CommentThread().insert(
+        title="Thread 1",
+        body="Thread 1",
+        course_id=course_id,
+        commentable_id="CommentThread",
+        author_id=user_id,
+        author_username=username,
+        abuse_flaggers=[],
+        historical_abuse_flaggers=[],
+    )
+    parent_comment_id = Comment().insert(
+        body="<p>Parent Comment</p>",
+        course_id=course_id,
+        author_id=user_id,
+        comment_thread_id=comment_thread_id,
+        author_username=username,
+    )
+    return user_id, comment_thread_id, parent_comment_id
+
+
+def test_comment_post_api(api_client: APIClient) -> None:
+    """
+    Test creating a new child comment.
+    """
+
+    user_id, thread_id, parent_comment_id = setup_models()
+
+    response = api_client.post_json(
+        f"/api/v2/comments/{parent_comment_id}",
+        data={
+            "body": "<p>Child Comment 1</p>",
+            "course_id": "course-xyz",
+            "user_id": user_id,
+            "parent_id": parent_comment_id,
+        },
+    )
+    assert response.status_code == 200
+    comment = response.json()
+    assert comment["body"] == "<p>Child Comment 1</p>"
+    assert comment["user_id"] == user_id
+    assert comment["thread_id"] == thread_id
+    assert comment["parent_id"] == parent_comment_id
+    parent_comment = Comment().get(parent_comment_id)
+    assert parent_comment is not None
+    assert parent_comment["child_count"] == 1
+
+
+def test_get_comment_api(api_client: APIClient) -> None:
+    """
+    Test retrieving a single parent comment.
+    """
+    _, _, parent_comment_id = setup_models()
+
+    response = api_client.get_json(f"/api/v2/comments/{parent_comment_id}")
+    assert response.status_code == 200
+    comment = response.json()
+    assert comment["body"] == "<p>Parent Comment</p>"
+    assert comment["endorsed"] is False
+    assert comment["id"] == parent_comment_id
+    assert comment["votes"]["point"] == 0
+    assert comment["depth"] == 0
+    assert comment["parent_id"] is None
+    assert comment["child_count"] == 0
+
+
+def test_update_comment_endorsed_api(api_client: APIClient) -> None:
+    """
+    Test updating the endorsed status of a parent comment.
+    """
+    user_id, _, parent_comment_id = setup_models()
+
+    response = api_client.put_json(
+        f"/api/v2/comments/{parent_comment_id}",
+        data={"endorsed": "True", "endorsement_user_id": user_id},
+    )
+    assert response.status_code == 200
+    comment = Comment().get(parent_comment_id)
+    assert comment is not None
+    assert comment["endorsed"] is True
+    assert comment["endorsement"]["user_id"] == user_id
+
+    response = api_client.put_json(
+        f"/api/v2/comments/{parent_comment_id}",
+        data={"endorsed": "False"},
+    )
+    assert response.status_code == 200
+    comment = Comment().get(parent_comment_id)
+    assert comment is not None
+    assert comment["endorsed"] is False
+    assert comment["endorsement"] is None
+
+
+def test_delete_comment_api(api_client: APIClient) -> None:
+    """
+    Test deleting a comment.
+    """
+
+    _, _, parent_comment_id = setup_models()
+
+    response = api_client.delete_json(f"/api/v2/comments/{parent_comment_id}")
+    assert response.status_code == 200
+    assert Comment().get(parent_comment_id) is None
+
+
+def test_returns_400_when_comment_does_not_exist(api_client: APIClient) -> None:
+    incorrect_comment_id = "66c42d4aa3a68c001c6c22db"
+    response = api_client.get_json(f"/api/v2/comments/{incorrect_comment_id}")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Comment does not exist"}
+
+    response = api_client.put_json(f"/api/v2/comments/{incorrect_comment_id}", data={})
+    assert response.status_code == 400
+    assert response.json() == {"error": "Comment does not exist"}
+
+    response = api_client.delete_json(f"/api/v2/comments/{incorrect_comment_id}")
+    assert response.status_code == 400
+    assert response.json() == {"error": "Comment does not exist"}
+
+
+def test_updates_body_correctly(api_client: APIClient) -> None:
+    """
+    Test updating the body of a comment.
+    """
+    _, _, parent_comment_id = setup_models()
+    comment = Comment().get(parent_comment_id)
+    assert comment is not None
+    original_body = comment["body"]
+    editing_user_id = "2"
+    editing_username = "user2"
+    Users().insert(editing_user_id, username=editing_username, email="email2")
+    edit_reason_code = "test_reason"
+    new_body = "new body"
+    response = api_client.put_json(
+        f"/api/v2/comments/{parent_comment_id}",
+        data={
+            "body": new_body,
+            "editing_user_id": editing_user_id,
+            "edit_reason_code": edit_reason_code,
+        },
+    )
+
+    assert response.status_code == 200
+    updated_comment = Comment().get(parent_comment_id)
+    assert updated_comment is not None
+    assert updated_comment["body"] == new_body
+    edit_history = updated_comment["edit_history"]
+    assert len(edit_history) == 1
+    assert edit_history[0]["original_body"] == original_body
+    assert edit_history[0]["reason_code"] == edit_reason_code
+    assert edit_history[0]["editor_username"] == editing_username
+
+
+def test_updates_body_correctly_without_user_id(api_client: APIClient) -> None:
+    """
+    Test updating the body of a comment without user id.
+    """
+
+    _, _, parent_comment_id = setup_models()
+    new_body = "new body"
+    response = api_client.put_json(
+        f"/api/v2/comments/{parent_comment_id}",
+        data={"body": new_body},
+    )
+    assert response.status_code == 200
+    updated_comment = Comment().get(parent_comment_id)
+    assert updated_comment is not None
+    assert updated_comment["body"] == new_body
+    assert ("edit_history" not in updated_comment) is True
+
+
+def test_update_endorsed_and_body_simultaneously(api_client: APIClient) -> None:
+    """
+    Test updating the body and endorse status of a comment simultaneously.
+    """
+
+    _, _, parent_comment_id = setup_models()
+    new_body = "new body"
+    response = api_client.put_json(
+        f"/api/v2/comments/{parent_comment_id}",
+        data={"endorsed": "True", "body": new_body},
+    )
+    assert response.status_code == 200
+    updated_comment = Comment().get(parent_comment_id)
+    assert updated_comment is not None
+    assert updated_comment["body"] == new_body
+    assert updated_comment["endorsement"] is None
+    assert updated_comment["endorsed"] is True


### PR DESCRIPTION
- migrated test cases from ruby to python for comments APIs
- modify client to handle all requests for tests
- some fixes while writing tests for comments APIs 
close #56 