### PR TITLE
chore: refactor serializers

### DIFF
--- a/forum/search/es_helper.py
+++ b/forum/search/es_helper.py
@@ -175,7 +175,7 @@ class ElasticsearchHelper:
         Process the response from a batch import operation.
 
         Args:
-            response (tuple[int, list[dict]]): Tuple containing the count of successful imports and a list of errors.
+            response (tuple[int, list[dict]]): tuple containing the count of successful imports and a list of errors.
             batch_number (int): The current batch number being processed.
         """
         success_count, errors = response
@@ -385,7 +385,7 @@ class ElasticsearchHelper:
             query (dict, optional): MongoDB query to filter documents. Defaults to None.
 
         Yields:
-            tuple[int, list[dict]]: Tuple containing the count of successful imports and a list of errors.
+            tuple[int, list[dict]]: tuple containing the count of successful imports and a list of errors.
         """
         cursor = model.find(query or {}).batch_size(batch_size)
         actions = []

--- a/forum/serializers/comment.py
+++ b/forum/serializers/comment.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from rest_framework import serializers
 
-from forum.serializers.contents import UserContentSerializer
+from forum.serializers.contents import ContentSerializer
 from forum.serializers.custom_datetime import CustomDateTimeField
 
 
@@ -31,11 +31,11 @@ class EndorsementSerializer(serializers.Serializer[dict[str, Any]]):
         raise NotImplementedError
 
 
-class UserCommentSerializer(UserContentSerializer):
+class CommentSerializer(ContentSerializer):
     """
     Serializer for handling user comments on threads.
 
-    Inherits from UserContentSerializer.
+    Inherits from ContentSerializer.
 
     Attributes:
         endorsed (bool): Whether the comment is endorsed by an authority.

--- a/forum/serializers/contents.py
+++ b/forum/serializers/contents.py
@@ -5,7 +5,7 @@ from typing import Any
 from rest_framework import serializers
 
 from forum.serializers.custom_datetime import CustomDateTimeField
-from forum.serializers.votes import VotesSerializer, VoteSummarySerializer
+from forum.serializers.votes import VoteSummarySerializer
 
 
 class EditHistorySerializer(serializers.Serializer[dict[str, Any]]):
@@ -34,71 +34,6 @@ class EditHistorySerializer(serializers.Serializer[dict[str, Any]]):
 
 
 class ContentSerializer(serializers.Serializer[dict[str, Any]]):
-    """
-    Serializer for the content data.
-
-    Attributes:
-        _id (CharField): The ID of the content.
-        votes (VotesSerializer): The votes data for the content.
-        visible (BooleanField): Whether the content is visible.
-        abuse_flaggers (ListField): List of user IDs who flagged the content for abuse.
-        historical_abuse_flaggers (ListField): List of user IDs who historically flagged the content for abuse.
-        parent_ids (ListField): List of parent IDs for the content.
-        at_position_list (ListField): List of positions for the content.
-        body (CharField): The body text of the content.
-        course_id (CharField): The ID of the course associated with the content.
-        _type (CharField): The type of content.
-        endorsed (BooleanField): Whether the content is endorsed.
-        anonymous (BooleanField): Whether the content is anonymous.
-        anonymous_to_peers (BooleanField): Whether the content is anonymous to peers.
-        parent_id (CharField): The ID of the parent content.
-        author_id (CharField): The ID of the author of the content.
-        comment_thread_id (CharField): The ID of the comment thread associated with the content.
-        child_count (IntegerField): The number of child comments.
-        depth (IntegerField): The depth of the content in the comment thread.
-        author_username (CharField): The username of the author of the content.
-        sk (CharField): The sorting key for the content.
-        updated_at (DateTimeField): The date and time the content was last updated.
-        created_at (DateTimeField): The date and time the content was created.
-    """
-
-    _id = serializers.CharField()
-    votes = VotesSerializer(allow_null=True)
-    visible = serializers.BooleanField(allow_null=True)
-    abuse_flaggers = serializers.ListField(
-        child=serializers.CharField(), allow_null=True
-    )
-    historical_abuse_flaggers = serializers.ListField(
-        child=serializers.CharField(), allow_null=True
-    )
-    parent_ids = serializers.ListField(child=serializers.CharField(), allow_null=True)
-    at_position_list = serializers.ListField(allow_null=True)
-    body = serializers.CharField(allow_null=True)
-    course_id = serializers.CharField(allow_null=True)
-    _type = serializers.CharField(allow_null=True)
-    endorsed = serializers.BooleanField(allow_null=True)
-    anonymous = serializers.BooleanField(allow_null=True)
-    anonymous_to_peers = serializers.BooleanField(allow_null=True)
-    parent_id = serializers.CharField(allow_null=True)
-    author_id = serializers.CharField(allow_null=True)
-    comment_thread_id = serializers.CharField(allow_null=True)
-    child_count = serializers.IntegerField(allow_null=True)
-    depth = serializers.IntegerField(allow_null=True)
-    author_username = serializers.CharField(allow_null=True)
-    sk = serializers.CharField(allow_null=True)
-    updated_at = CustomDateTimeField(allow_null=True)
-    created_at = CustomDateTimeField(allow_null=True)
-
-    def create(self, validated_data: dict[str, Any]) -> Any:
-        """Raise NotImplementedError"""
-        raise NotImplementedError
-
-    def update(self, instance: Any, validated_data: dict[str, Any]) -> Any:
-        """Raise NotImplementedError"""
-        raise NotImplementedError
-
-
-class UserContentSerializer(serializers.Serializer[dict[str, Any]]):
     """
     Serializer for handling the content of a post or comment.
 

--- a/forum/views/comments.py
+++ b/forum/views/comments.py
@@ -12,7 +12,7 @@ from rest_framework.views import APIView
 
 from forum.models import Comment, CommentThread
 from forum.models.model_utils import validate_object
-from forum.serializers.comment import UserCommentSerializer
+from forum.serializers.comment import CommentSerializer
 from forum.utils import str_to_bool
 
 
@@ -74,11 +74,11 @@ def prepare_comment_api_response(
         "parent_id": str(comment.get("parent_id")),
         "type": str(comment.get("_type", "")).lower(),
     }
-    serializer = UserCommentSerializer(
+    serializer = CommentSerializer(
         data=comment_data,
         exclude_fields=exclude_fields,
     )
-    if not serializer.is_valid():
+    if not serializer.is_valid(raise_exception=True):
         raise ValidationError(serializer.errors)
 
     return serializer.data

--- a/forum/views/flags.py
+++ b/forum/views/flags.py
@@ -12,8 +12,8 @@ from forum.models.model_utils import (
     un_flag_all_as_abuse,
     un_flag_as_abuse,
 )
-from forum.serializers.comment import UserCommentSerializer
-from forum.serializers.thread import UserThreadSerializer
+from forum.serializers.comment import CommentSerializer
+from forum.serializers.thread import ThreadSerializer
 
 
 class CommentFlagAPIView(APIView):
@@ -71,7 +71,7 @@ class CommentFlagAPIView(APIView):
             "type": "comment",
             "thread_id": str(updated_comment.get("comment_thread_id", None)),
         }
-        serializer = UserCommentSerializer(context)
+        serializer = CommentSerializer(context)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
@@ -131,5 +131,5 @@ class ThreadFlagAPIView(APIView):
             "type": "thread",
             "thread_id": str(updated_thread.get("comment_thread_id", None)),
         }
-        serializer = UserThreadSerializer(context)
+        serializer = ThreadSerializer(context)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/forum/views/pins.py
+++ b/forum/views/pins.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from forum.models.model_utils import handle_pin_unpin_thread_request
-from forum.serializers.thread import UserThreadSerializer
+from forum.serializers.thread import ThreadSerializer
 
 
 class PinThreadAPIView(APIView):
@@ -33,7 +33,7 @@ class PinThreadAPIView(APIView):
         """
         try:
             thread_data: dict[str, Any] = handle_pin_unpin_thread_request(
-                request.data.get("user_id", ""), thread_id, "pin", UserThreadSerializer
+                request.data.get("user_id", ""), thread_id, "pin", ThreadSerializer
             )
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
@@ -65,7 +65,7 @@ class UnpinThreadAPIView(APIView):
                 request.data.get("user_id", ""),
                 thread_id,
                 "unpin",
-                UserThreadSerializer,
+                ThreadSerializer,
             )
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/forum/views/search.py
+++ b/forum/views/search.py
@@ -2,7 +2,7 @@
 Search API Views
 """
 
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from rest_framework import status
 from rest_framework.request import Request
@@ -40,7 +40,7 @@ class SearchThreadsView(APIView):
 
     def _get_thread_ids_from_indexes(
         self, context: str, group_ids: list[int], params: dict[str, Any], text: str
-    ) -> Tuple[list[str], Optional[str]]:
+    ) -> tuple[list[str], Optional[str]]:
         """
         Retrieve thread IDs based on the search text and suggested corrections if necessary.
 
@@ -51,7 +51,7 @@ class SearchThreadsView(APIView):
             text (str): The search text used to find threads.
 
         Returns:
-            Tuple[Optional[list[str]], Optional[str]]:
+            tuple[Optional[list[str]], Optional[str]]:
                 - A list of thread IDs that match the search criteria.
                 - A suggested correction for the search text, or None if no correction is found.
         """

--- a/forum/views/subscriptions.py
+++ b/forum/views/subscriptions.py
@@ -18,7 +18,7 @@ from forum.models.model_utils import (
 )
 from forum.pagination import ForumPagination
 from forum.serializers.subscriptions import SubscriptionSerializer
-from forum.serializers.thread import UserThreadSerializer
+from forum.serializers.thread import ThreadSerializer
 
 
 class SubscriptionAPIView(APIView):
@@ -153,7 +153,7 @@ class UserSubscriptionAPIView(APIView):
             int(params.get("page", 1)),
             int(params.get("per_page", 100)),
         )
-        serializer = UserThreadSerializer(threads.pop("collection"), many=True)
+        serializer = ThreadSerializer(threads.pop("collection"), many=True)
         threads["collection"] = serializer.data
         return Response(data=threads, status=status.HTTP_200_OK)
 

--- a/forum/views/votes.py
+++ b/forum/views/votes.py
@@ -11,8 +11,8 @@ from rest_framework.views import APIView
 
 from forum.models import Comment, CommentThread, Users
 from forum.models.model_utils import downvote_content, remove_vote, upvote_content
-from forum.serializers.comment import UserCommentSerializer
-from forum.serializers.thread import UserThreadSerializer
+from forum.serializers.comment import CommentSerializer
+from forum.serializers.thread import ThreadSerializer
 from forum.serializers.votes import VotesInputSerializer
 
 
@@ -90,7 +90,7 @@ class ThreadVoteView(APIView):
             "username": user["username"],
             "type": "thread",
         }
-        serializer = UserThreadSerializer(data=context)
+        serializer = ThreadSerializer(data=context)
         if not serializer.is_valid():
             raise ValueError(serializer.errors)
         return serializer.data
@@ -225,7 +225,7 @@ class CommentVoteView(APIView):
             "type": "comment",
             "thread_id": str(comment.get("comment_thread_id", None)),
         }
-        serializer = UserCommentSerializer(data=context)
+        serializer = CommentSerializer(data=context)
         if not serializer.is_valid():
             raise ValueError(serializer.errors)
         return serializer.data


### PR DESCRIPTION
In this PR:
- refactored serializers, now there's only one serializer for comment and thread and both inherits a single content serializer.
- Also tried overriding is_valid() method of serializer but mypy and pylint were conflicting together.
- rename serializers
