### PR TITLE
fix: issues in comment_count & subscriptions api

### DIFF
--- a/forum/models/contents.py
+++ b/forum/models/contents.py
@@ -97,6 +97,20 @@ class BaseContents(MongoBaseModel):
         )
         return result.modified_count
 
+    def update_count(self, content_id: str, query: dict[str, Any]) -> int:
+        """
+        Updates count of a field in the content document based on query.
+
+        Args:
+            content_id (str): The id of the content(Commentthread id or Comment id) model.
+            query (dict[str, Any]): Query to update the count in a specific field.
+        """
+        result = self._collection.update_one(
+            {"_id": ObjectId(content_id)},
+            query,
+        )
+        return result.modified_count
+
 
 class Contents(BaseContents):
     """

--- a/forum/models/model_utils.py
+++ b/forum/models/model_utils.py
@@ -202,14 +202,6 @@ def remove_vote(thread: dict[str, Any], user: dict[str, Any]) -> bool:
     return update_vote(thread, user, is_deleted=True)
 
 
-def get_comments_count(thread_id: str) -> int:
-    """
-    Returns that comments count in a perticular thread
-    """
-    comments = list(Comment().list(comment_thread_id=ObjectId(thread_id)))
-    return len(comments) if comments else 0
-
-
 def validate_thread_and_user(
     user_id: str, thread_id: str
 ) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/forum/serializers/thread.py
+++ b/forum/serializers/thread.py
@@ -8,7 +8,6 @@ from rest_framework import serializers
 
 from forum.models.model_utils import (
     get_abuse_flagged_count,
-    get_comments_count,
     get_endorsed,
     get_read_states,
     get_username_from_id,
@@ -32,7 +31,7 @@ class ThreadSerializer(ContentSerializer):
         tags (list): A list of tags associated with the thread.
         group_id (str or None): The ID of the group associated with the thread, if any.
         pinned (bool): Whether the thread is pinned at the top of the list.
-        comments_count (int): The number of comments on the thread.
+        comment_count (int): The number of comments on the thread.
 
     This serializer extends the `ThreadSerializer` and customizes fields based on various context
     parameters. It manages fields related to read state, comment counts, endorsements, abuse flags,
@@ -59,7 +58,7 @@ class ThreadSerializer(ContentSerializer):
     tags = serializers.ListField(default=[])
     group_id = serializers.CharField(allow_null=True, default=None)
     pinned = serializers.BooleanField(default=False)
-    comments_count = serializers.SerializerMethodField()
+    comment_count = serializers.IntegerField(default=0)
     read = serializers.SerializerMethodField()
     unread_comments_count = serializers.SerializerMethodField()
     endorsed = serializers.SerializerMethodField()
@@ -126,7 +125,7 @@ class ThreadSerializer(ContentSerializer):
             course_id = obj["course_id"]
             thread_key = obj["id"]
             is_read, _ = get_read_states([obj], user_id, course_id).get(
-                thread_key, (False, obj["comments_count"])
+                thread_key, (False, obj["comment_count"])
             )
             return is_read
         return None
@@ -148,7 +147,7 @@ class ThreadSerializer(ContentSerializer):
             course_id = obj["course_id"]
             thread_key = obj["id"]
             _, unread_count = get_read_states([obj], user_id, course_id).get(
-                thread_key, (False, obj["comments_count"])
+                thread_key, (False, obj["comment_count"])
             )
             return unread_count
         return None
@@ -242,11 +241,6 @@ class ThreadSerializer(ContentSerializer):
     def update(self, instance: Any, validated_data: dict[str, Any]) -> Any:
         """Raise NotImplementedError"""
         raise NotImplementedError
-
-    def get_comments_count(self, obj: dict[str, Any]) -> int:
-        """Retrieve the count of comments for the given thread."""
-        count = get_comments_count(obj["_id"])
-        return count
 
     def get_closed_by(self, obj: dict[str, Any]) -> Optional[str]:
         """Retrieve the username of the person who closed the object."""

--- a/forum/views/comments.py
+++ b/forum/views/comments.py
@@ -41,8 +41,8 @@ def create_comment(
     new_comment_id = Comment().insert(
         body=data["body"],
         course_id=data["course_id"],
-        anonymous=data.get("anonymous", False),
-        anonymous_to_peers=data.get("anonymous_to_peers", False),
+        anonymous=str_to_bool(data.get("anonymous", "False")),
+        anonymous_to_peers=str_to_bool(data.get("anonymous_to_peers", "False")),
         author_id=data["user_id"],
         comment_thread_id=thread_id,
         parent_id=parent_id,
@@ -114,7 +114,7 @@ class CommentsAPIView(APIView):
             )
         data = prepare_comment_api_response(
             comment,
-            exclude_fields=["sk"],
+            exclude_fields=["sk", "endorsement"],
         )
         return Response(data, status=status.HTTP_200_OK)
 

--- a/forum/views/subscriptions.py
+++ b/forum/views/subscriptions.py
@@ -180,6 +180,7 @@ class UserSubscriptionAPIView(APIView):
             "sort_key",
             "page",
             "per_page",
+            "request_id'",
         ]
 
         for key in params:


### PR DESCRIPTION
- `comment_count` is calculated on run time during API call in a `ThreadSerializer` and returned in a response. As a result, it does not sync with mongodb data. So it should be updated through a signal or in current implementation of mongo models, `comment_count` should be adjusted when there's any comment created/deleted. This commit will fix this issue and will update comment_count when comment is created/deleted.
- fix an issue in user subscriptions get request params validation.
- fix an issue in field name comment_count in the `ThreadSerializer`.
- code refactoring
- exclude endorsement field in case of get comment data and only save parent_id for child comment. This will keep the responses same for v1 and v2. 