### PR TITLE
FC-0057: implement commentables count API

### DIFF
--- a/forum/urls.py
+++ b/forum/urls.py
@@ -4,6 +4,7 @@ URLs for forum.
 
 from django.urls import include, path
 
+from forum.views.commentables import CommentablesCountAPIView
 from forum.views.comments import CommentsAPIView, CreateThreadCommentAPIView
 from forum.views.flags import CommentFlagAPIView, ThreadFlagAPIView
 from forum.views.pins import PinThreadAPIView, UnpinThreadAPIView
@@ -95,6 +96,12 @@ api_patterns = [
         "threads/<str:thread_id>",
         ThreadsAPIView.as_view(),
         name="threads-api",
+    ),
+    # commentables API
+    path(
+        "commentables/<str:course_id>/counts",
+        CommentablesCountAPIView.as_view(),
+        name="commentables-count",
     ),
     # Proxy view for various API endpoints
     path(

--- a/forum/views/commentables.py
+++ b/forum/views/commentables.py
@@ -1,0 +1,35 @@
+"""Forum Comments API Views."""
+
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from forum.models.model_utils import get_commentables_counts_based_on_type
+
+
+class CommentablesCountAPIView(APIView):
+    """
+    API View to handle GET request for commentables count.
+    """
+
+    permission_classes = (AllowAny,)
+
+    def get(self, request: Request, course_id: str) -> Response:
+        """
+        Retrieves a the threads count based on thread_type.
+
+        Parameters:
+            request (Request): The incoming request.
+            course_id: The ID of the course.
+        Body:
+            Empty.
+        Response:
+            The threads count for the given course_id based on thread_type.
+        """
+        commentable_counts = get_commentables_counts_based_on_type(course_id)
+        return Response(
+            commentable_counts,
+            status=status.HTTP_200_OK,
+        )

--- a/tests/test_views/test_commentables.py
+++ b/tests/test_views/test_commentables.py
@@ -1,0 +1,56 @@
+"""Test commentables count api endpoint."""
+
+import random
+import uuid
+
+from forum.models import CommentThread
+from test_utils.client import APIClient
+
+
+def test_get_commentables_counts_api(api_client: APIClient) -> None:
+    """
+    Test retrieving counts of discussion and question threads for multiple commentables within a course.
+    """
+    course_id = "abcd"
+    id_map = {}
+
+    for _ in range(5):
+        commentable_id = str(uuid.uuid4())
+        question_count = random.randint(5, 15)
+        discussion_count = random.randint(5, 15)
+
+        for _ in range(question_count):
+            CommentThread().insert(
+                title="Question Thread",
+                body="This is a question thread.",
+                course_id=course_id,
+                commentable_id=commentable_id,
+                thread_type="question",
+                author_id="test_user_id",
+                author_username="test_user",
+                abuse_flaggers=[],
+                historical_abuse_flaggers=[],
+            )
+
+        for _ in range(discussion_count):
+            CommentThread().insert(
+                title="Discussion Thread",
+                body="This is a discussion thread.",
+                course_id=course_id,
+                commentable_id=commentable_id,
+                thread_type="discussion",
+                author_id="test_user_id",
+                author_username="test_user",
+                abuse_flaggers=[],
+                historical_abuse_flaggers=[],
+            )
+
+        id_map[commentable_id] = {
+            "question": question_count,
+            "discussion": discussion_count,
+        }
+
+    response = api_client.get_json(f"/api/v2/commentables/{course_id}/counts")
+
+    assert response.status_code == 200
+    assert response.json() == id_map


### PR DESCRIPTION
- implement commentables count API
- fix invalid parameter 'commentable_ids' error for threads API 
- implement tests for commentables count API
- close #74

This PR doesn't include below APIs as below APIs weren't being called from the frontend.
```
/:commentable_id/threads DELETE
/:commentable_id/threads GET
/:commentable_id/threads POST
```
