### PR TITLE
fix: flags api not updating historical abuse flaggers

### DIFF
--- a/forum/models/contents.py
+++ b/forum/models/contents.py
@@ -229,6 +229,7 @@ class Contents(BaseContents):
         _id: str,
         author_username: Optional[str] = None,
         abuse_flaggers: Optional[list[str]] = None,
+        historical_abuse_flaggers: Optional[list[str]] = None,
         body: Optional[str] = None,
         title: Optional[str] = None,
         **kwargs: Any
@@ -246,6 +247,7 @@ class Contents(BaseContents):
         fields = [
             ("author_username", author_username),
             ("abuse_flaggers", abuse_flaggers),
+            ("historical_abuse_flaggers", historical_abuse_flaggers),
             ("body", body),
             ("title", title),
         ]

--- a/forum/models/model_utils.py
+++ b/forum/models/model_utils.py
@@ -115,14 +115,11 @@ def un_flag_as_abuse(
     return Contents().get(entity["_id"])
 
 
-def un_flag_all_as_abuse(
-    user_id: str, entity: dict[str, Any]
-) -> Union[dict[str, Any], None]:
+def un_flag_all_as_abuse(entity: dict[str, Any]) -> Union[dict[str, Any], None]:
     """
     Unflag an entity as abuse for all users.
 
     Args:
-        user_id str: The user unflagging the entity.
         entity (dict[str, Any]): The entity being unflagged as abuse.
 
     Returns:
@@ -135,15 +132,14 @@ def un_flag_all_as_abuse(
     historical_abuse_flaggers = list(
         set(entity["historical_abuse_flaggers"]) | set(entity["abuse_flaggers"])
     )
-    if user_id in entity["abuse_flaggers"]:
-        Contents().update(
-            entity["_id"],
-            abuse_flaggers=entity["abuse_flaggers"].remove(user_id),
-            historical_abuse_flaggers=historical_abuse_flaggers,
-        )
-        update_stats_after_unflag(
-            entity["author_id"], entity["_id"], has_no_historical_flags
-        )
+    Contents().update(
+        entity["_id"],
+        abuse_flaggers=[],
+        historical_abuse_flaggers=historical_abuse_flaggers,
+    )
+    update_stats_after_unflag(
+        entity["author_id"], entity["_id"], has_no_historical_flags
+    )
 
     return Contents().get(entity["_id"])
 

--- a/forum/serializers/contents.py
+++ b/forum/serializers/contents.py
@@ -51,6 +51,7 @@ class ContentSerializer(serializers.Serializer[dict[str, Any]]):
         commentable_id (str): The ID of the entity the content is related to (e.g., course).
         votes (VoteSummarySerializer): A summary of votes on the content.
         abuse_flaggers (list): A list of user IDs who flagged the content as abusive.
+        historical_abuse_flaggers (list): A list of user IDs who historically flagged the content as abusive.
         edit_history (list): A list of previous versions of the content.
         closed (bool): Whether the content is closed for further interactions.
         type (str): The type of content (e.g., "post", "comment").
@@ -69,6 +70,9 @@ class ContentSerializer(serializers.Serializer[dict[str, Any]]):
     commentable_id = serializers.CharField(default="course")
     votes = VoteSummarySerializer()
     abuse_flaggers = serializers.ListField(
+        child=serializers.CharField(), allow_null=True
+    )
+    historical_abuse_flaggers = serializers.ListField(
         child=serializers.CharField(), allow_null=True
     )
     edit_history = EditHistorySerializer(default=[], many=True)

--- a/forum/views/flags.py
+++ b/forum/views/flags.py
@@ -49,7 +49,7 @@ class CommentFlagAPIView(APIView):
             updated_comment = flag_as_abuse(user, comment)
         elif action == "unflag":
             if request_data.get("all") and request_data.get("all") is True:
-                updated_comment = un_flag_all_as_abuse(user["_id"], comment)
+                updated_comment = un_flag_all_as_abuse(comment)
             else:
                 updated_comment = un_flag_as_abuse(user, comment)
         else:
@@ -108,7 +108,7 @@ class ThreadFlagAPIView(APIView):
             updated_thread = flag_as_abuse(user, thread)
         elif action == "unflag":
             if request_data.get("all"):
-                updated_thread = un_flag_all_as_abuse(user["_id"], thread)
+                updated_thread = un_flag_all_as_abuse(thread)
             else:
                 updated_thread = un_flag_as_abuse(user, thread)
         else:

--- a/tests/test_views/test_flags.py
+++ b/tests/test_views/test_flags.py
@@ -109,3 +109,93 @@ def test_comment_flag_api_invalid_data(api_client: APIClient) -> None:
     )
     assert response.status_code == 400
     assert response.json() == {"error": "User / Comment doesn't exist"}
+
+
+def test_comment_flag_api_with_all_param(api_client: APIClient) -> None:
+    """
+    Test the comment flag API with the `all` parameter.
+
+    This test checks that a user can flag a comment for abuse and then unflag it using all.
+    """
+    flag_user = str(ObjectId())
+    flag_user_2 = str(ObjectId())
+    author_user = str(ObjectId())
+    Users().insert(flag_user, flag_user)
+    Users().insert(flag_user_2, flag_user_2)
+    Users().insert(author_user, author_user)
+    course_id = "course-xyz"
+    comment_thread_id = CommentThread().insert(
+        title="Test Thread",
+        body="This is a test thread",
+        course_id="course1",
+        commentable_id="commentable1",
+        author_id=author_user,
+        author_username=author_user,
+    )
+    comment_id = Comment().insert(
+        "<p>Comment 1</p>",
+        course_id,
+        author_user,
+        comment_thread_id=comment_thread_id,
+        author_username=author_user,
+        abuse_flaggers=[],
+        historical_abuse_flaggers=[],
+    )
+
+    comment = Comment().get(comment_id)
+    assert comment is not None
+    assert comment["abuse_flaggers"] == []
+
+    response = api_client.put_json(
+        f"/api/v2/comments/{comment_id}/abuse_flag",
+        data={"user_id": flag_user},
+    )
+
+    assert response.status_code == 200
+    flagged_comment = response.json()
+    assert flagged_comment["abuse_flaggers"] == [str(flag_user)]
+
+    response = api_client.put_json(
+        f"/api/v2/comments/{comment_id}/abuse_flag",
+        data={"user_id": flag_user_2},
+    )
+
+    assert response.status_code == 200
+    flagged_comment = response.json()
+    assert flagged_comment["abuse_flaggers"] == [flag_user, flag_user_2]
+    assert flagged_comment["historical_abuse_flaggers"] == []
+
+    response = api_client.put_json(
+        path=f"/api/v2/comments/{comment_id}/abuse_unflag",
+        data={"user_id": flag_user, "all": True},
+    )
+
+    assert response.status_code == 200
+    unflagged_comment = response.json()
+    assert unflagged_comment is not None
+    assert unflagged_comment["abuse_flaggers"] == []
+    assert set(unflagged_comment["historical_abuse_flaggers"]) == set(
+        [flag_user, flag_user_2]
+    )
+
+    # Test thread abuse and unabuse.
+    response = api_client.put_json(
+        f"/api/v2/threads/{comment_thread_id}/abuse_flag",
+        data={"user_id": flag_user},
+    )
+
+    assert response.status_code == 200
+    flagged_thread = response.json()
+    assert flagged_thread["abuse_flaggers"] == [flag_user]
+    assert flagged_thread["historical_abuse_flaggers"] == []
+
+    response = api_client.put_json(
+        path=f"/api/v2/threads/{comment_thread_id}/abuse_unflag",
+        data={"user_id": flag_user, "all": True},
+    )
+
+    assert response.status_code == 200
+    unflagged_thread = response.json()
+    assert unflagged_thread is not None
+    assert unflagged_thread["abuse_flaggers"] == []
+    assert unflagged_thread["historical_abuse_flaggers"] == [flag_user]


### PR DESCRIPTION
This pr fixes flags api to update historical abuse flaggers when unflag api is called with  param set to true. Also, add historical_abuse_flaggers field in Contents serializer.



