### PR TITLE
refactor: forum mongodb settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ In certain scenarios, you may need to mount the Forum package for extending or d
 
 4. Install this plugin::
 
-    tutor plugins install https://gist.githubusercontent.com/taimoor-ahmed-1/9e947a06d127498a328475877e41d7c0/raw/6152bdc312f941e79d50e2043f00d3d059de70a7/forum-v2.py
+    tutor plugins install https://gist.githubusercontent.com/taimoor-ahmed-1/9e947a06d127498a328475877e41d7c0/raw/c5ec777303c4f558eb58e667aa5ce65dbf4d487f/forumv2.py
 
 5. Enable the plugin::
 

--- a/forum/settings/common.py
+++ b/forum/settings/common.py
@@ -11,8 +11,12 @@ def plugin_settings(settings: Any) -> None:
     Set these variables in the Tutor Config or lms.yml for local testing
     """
     settings.FORUM_PORT = "4567"
-    settings.FORUM_MONGO_HOST = "mongodb"
-    settings.FORUM_MONGO_PORT = 27017
+    settings.FORUM_MONGO_HOST = getattr(
+        settings, "FORUM_MONGO_HOST", getattr(settings, "MONGO_HOST", "mongodb")
+    )
+    settings.FORUM_MONGO_PORT = getattr(
+        settings, "FORUM_MONGO_PORT", getattr(settings, "MONGO_HOST", 27017)
+    )
 
     settings.ELASTIC_SEARCH_CONFIG = [
         {

--- a/forum/settings/production.py
+++ b/forum/settings/production.py
@@ -11,10 +11,10 @@ def plugin_settings(settings: Any) -> None:
     """
     settings.FORUM_PORT = settings.ENV_TOKENS.get("FORUM_PORT", settings.FORUM_PORT)
     settings.FORUM_MONGO_HOST = settings.ENV_TOKENS.get(
-        "FORUM_MONGO_HOST", settings.FORUM_MONGO_HOST
+        "FORUM_MONGO_HOST", getattr(settings, "MONGO_HOST", "mongodb")
     )
     settings.FORUM_MONGO_PORT = settings.ENV_TOKENS.get(
-        "FORUM_MONGO_PORT", settings.FORUM_MONGO_PORT
+        "FORUM_MONGO_PORT", getattr(settings, "MONGO_PORT", 27017)
     )
     settings.ELASTIC_SEARCH_CONFIG = settings.ENV_TOKENS.get(
         "ELASTIC_SEARCH_CONFIG", settings.ELASTIC_SEARCH_CONFIG


### PR DESCRIPTION
This PR updates settings for forum mongodb settings to use edx-platform's settings and if not available use default settings. 
Also, updated gist for tutor forumv2 to add ENV_PATCHES hook that set mongodb host and port.
close #045

