### PR TITLE
test: slightly faster user tests

### DIFF
--- a/tests/test_views/test_users.py
+++ b/tests/test_views/test_users.py
@@ -99,14 +99,14 @@ def fixture_build_structure_and_response() -> dict[str, Any]:
             if historical_abuse_flaggers_comment:
                 expected_data[comment_author]["inactive_flags"] += 1
 
+            comment = Comment().get(comment_id)
+            if not comment:
+                continue
+            Comment().update(
+                comment_id,
+                child_count=comment["child_count"],
+            )
             for _ in range(3):
-                comment = Comment().get(comment_id)
-                if not comment:
-                    continue
-                Comment().update(
-                    comment_id,
-                    child_count=comment["child_count"],
-                )
                 reply_author = random.choice(authors)
                 expected_data[reply_author]["replies"] += 1
                 reply_id = Comment().insert(


### PR DESCRIPTION
This is an attempt to make the user stats tests slightly faster. Turns out that the setup function was migrated from forum v1, so it's probably better that we don't change the code too much until we've reached stable status.

With this changes, we observe ~20% improvement in the top 4 user tests:

0.82s setup tests/test_views/test_users.py::test_returns_users_stats_with_default_activity_sort 0.81s setup tests/test_views/test_users.py::test_update_user_stats 0.81s setup tests/test_views/test_users.py::test_returns_users_stats_filtered_by_user_with_default_activity_sort 0.80s setup tests/test_views/test_users.py::test_returns_users_stats_with_flagged_sort 0.76s call  tests/test_views/test_search.py::test_pagination

These slow tests were migrated from forum v1, so it's probably better that we don't change the code too much until we've reached stable status.

This was meant to address #94, but we didn't really manage to resolve the issue fully.
