### PR TITLE
feat: add migration command for mongo to mysql

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,81 @@ Optionally, you may checkout the `edly-io/forum_v2 <https://github.com/edly-io/e
     git checkout forum_v2
     tutor mounts add .
 
+Forum v2 Waffle Flag
+********************
+
+Description
+-----------
+The ``forum_v2.enable_mysql_backend`` waffle flag is used to toggle the use of the MySQL backend instead of the MongoDB backend.
+
+Details
+-------
+- **Toggle Name**: ``forum_v2.enable_mysql_backend``
+- **Implementation**: CourseWaffleFlag
+- **Default**: False
+- **Description**: Waffle flag to use the MySQL backend instead of Mongo backend.
+- **Use Cases**: temporary, open_edx
+- **Creation Date**: 2025-12-05
+- **Target Removal Date**: 2025-12-05
+
+Usage
+-----
+This waffle flag is automatically enabled for a course when the ``migrate_courses_to_mysql`` command is run for that course. It can also be manually added through the Django admin interface.
+
+Migration from MongoDB to MySQL backend:
+****************************************
+
+    python manage.py forum_migrate_course_from_mongodb_to_mysql
+
+Description
+-----------
+This command migrates data from MongoDB to MySQL for the specified courses.
+
+Usage
+-----
+To migrate data for a specific course(s), run the command with the course ID(s) as argument:
+
+   python manage.py forum_migrate_course_from_mongodb_to_mysql <course_id_1> <course_id_2>
+
+To migrate data for all courses, run the command with the ``all`` argument:
+
+   python manage.py forum_migrate_course_from_mongodb_to_mysql all
+
+What the command does
+---------------------
+The command performs the following steps:
+
+1. **Migrates user data**: Migrates user data from MongoDB to MySQL.
+2. **Migrates content data**: Migrates content data from MongoDB to MySQL.
+3. **Migrates read state data**: Migrates read state data from MongoDB to MySQL.
+4. **Enables waffle flag**: Enables the ``forum_v2.enable_mysql_backend`` waffle flag for the specified course.
+
+
+``python manage.py forum_delete_course_from_mongodb``
+
+Description
+-----------
+This command deletes course data from MongoDB for the specified courses.
+
+Usage
+-----
+To delete data for a specific course(s), run the command with the course ID(s) as an argument:
+
+   python manage.py forum_delete_course_from_mongodb <course_id_1> <course_id_2>
+
+To delete data for all courses, run the command with the ``all`` argument:
+
+   python manage.py forum_delete_course_from_mongodb all
+
+Options
+-------
+* ``--dry-run``: Perform a dry run without actually deleting data.
+
+Example
+-------
+
+   python manage.py forum_delete_course_from_mongodb <course_id> --dry-run
+
 .. Deploying
 .. *********
 

--- a/forum/management/commands/forum_delete_course_from_mongodb.py
+++ b/forum/management/commands/forum_delete_course_from_mongodb.py
@@ -1,0 +1,52 @@
+"""Deletion command for a course data in mongodb."""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+
+from forum.migration_helpers import delete_course_data, get_all_course_ids
+from forum.mongo import get_database
+
+
+class Command(BaseCommand):
+    """Deletion command for a course data in mongodb."""
+
+    help = "Delete data from MongoDB for specific courses or all courses"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "courses", nargs="+", type=str, help="List of course IDs or `all`"
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Perform a dry run without actually deleting data",
+        )
+
+    def handle(self, *args: str, **options: dict[str, Any]) -> None:
+        """Handle method for command."""
+        db = get_database()
+
+        courses: list[str] = list(options["courses"])
+        dry_run: bool = bool(options["dry_run"])
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING("Performing dry run. No data will be deleted.")
+            )
+
+        if "all" in courses:
+            courses = get_all_course_ids(db)
+
+        for course_id in courses:
+            self.stdout.write(f"Deleting data for course: {course_id}")
+            delete_course_data(db, course_id, dry_run, self.stdout)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS("Dry run completed. No data was deleted.")
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS("Data deletion completed successfully")
+            )

--- a/forum/management/commands/forum_migrate_course_from_mongodb_to_mysql.py
+++ b/forum/management/commands/forum_migrate_course_from_mongodb_to_mysql.py
@@ -1,0 +1,47 @@
+"""Migration command for courses from mongodb to mysql."""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandParser
+
+from forum.migration_helpers import (
+    enable_mysql_backend_for_course,
+    get_all_course_ids,
+    migrate_content,
+    migrate_read_states,
+    migrate_users,
+)
+from forum.mongo import get_database
+
+
+class Command(BaseCommand):
+    """Migration command for courses from mongodb to mysql."""
+
+    help = "Migrate data from MongoDB to MySQL"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """Add arguments to the command."""
+        parser.add_argument(
+            "courses", nargs="+", type=str, help="List of course IDs or `all`"
+        )
+
+    def handle(self, *args: str, **options: dict[str, Any]) -> None:
+        """Handle the command."""
+        db = get_database()
+
+        courses = list(options["courses"])
+        if "all" in courses:
+            courses = get_all_course_ids(db)
+
+        for course_id in courses:
+            self.stdout.write(f"Migrating data for course: {course_id}")
+            migrate_users(db, course_id)
+            migrate_content(db, course_id)
+            migrate_read_states(db, course_id)
+            enable_mysql_backend_for_course(course_id)
+            self.stdout.write(
+                f"Enabled mysql backend waffle flag for course {course_id}."
+            )
+
+        self.stdout.write(self.style.SUCCESS("Data migration completed successfully"))

--- a/forum/migration_helpers.py
+++ b/forum/migration_helpers.py
@@ -1,0 +1,255 @@
+"""Migration commands helper methods."""
+
+from typing import Any
+
+from django.contrib.auth.models import User  # pylint: disable=E5142
+from django.core.management.base import OutputWrapper
+from django.utils import timezone
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+from forum.models import (
+    ForumUser,
+    CourseStat,
+    ReadState,
+    LastReadTime,
+    CommentThread,
+    Comment,
+    UserVote,
+    Subscription,
+)
+
+
+def get_all_course_ids(db: Database[dict[str, Any]]) -> list[str]:
+    """Get all course IDs from MongoDB."""
+    return db.contents.distinct("course_id")
+
+
+def migrate_users(db: Database[dict[str, Any]], course_id: str) -> None:
+    """Migrate users from MongoDB to MySQL."""
+    users = db.users.find({"course_stats.course_id": course_id})
+    for user_data in users:
+        user, _ = User.objects.get_or_create(
+            id=int(user_data["_id"]), defaults={"username": user_data["username"]}
+        )
+
+        _, _ = ForumUser.objects.get_or_create(
+            user=user,
+            defaults={"default_sort_key": user_data.get("default_sort_key", "date")},
+        )
+
+        for stat in user_data.get("course_stats", []):
+            if stat["course_id"] == course_id:
+                CourseStat.objects.update_or_create(
+                    user=user,
+                    course_id=course_id,
+                    defaults={
+                        "active_flags": stat.get("active_flags", 0),
+                        "inactive_flags": stat.get("inactive_flags", 0),
+                        "threads": stat.get("threads", 0),
+                        "responses": stat.get("responses", 0),
+                        "replies": stat.get("replies", 0),
+                        "last_activity_at": stat.get("last_activity_at"),
+                    },
+                )
+
+
+def migrate_content(db: Database[dict[str, Any]], course_id: str) -> None:
+    """Migrate content from MongoDB to MySQL."""
+    contents = db.contents.find({"course_id": course_id})
+    for content in contents:
+        if content["_type"] == "CommentThread":
+            create_or_update_thread(content)
+        elif content["_type"] == "Comment":
+            create_or_update_comment(content)
+
+        migrate_subscriptions(db, content["_id"])
+
+
+def create_or_update_thread(thread_data: dict[str, Any]) -> None:
+    """Create or update a thread."""
+    author = User.objects.get(id=int(thread_data["author_id"]))
+    thread, _ = CommentThread.objects.update_or_create(
+        id=int(str(thread_data["_id"]), 16),
+        defaults={
+            "author": author,
+            "course_id": thread_data["course_id"],
+            "title": thread_data.get("title", ""),
+            "body": thread_data["body"],
+            "thread_type": thread_data.get("thread_type", "discussion"),
+            "context": thread_data.get("context", "course"),
+            "anonymous": thread_data.get("anonymous", False),
+            "anonymous_to_peers": thread_data.get("anonymous_to_peers", False),
+            "closed": thread_data.get("closed", False),
+            "pinned": thread_data.get("pinned"),
+            "created_at": thread_data["created_at"],
+            "updated_at": thread_data["updated_at"],
+        },
+    )
+    create_votes(thread, thread_data.get("votes", {}))
+
+
+def create_or_update_comment(comment_data: dict[str, Any]) -> None:
+    """Create or update a comment."""
+    author = User.objects.get(id=int(comment_data["author_id"]))
+    thread = CommentThread.objects.get(
+        id=int(str(comment_data["comment_thread_id"]), 16)
+    )
+    parent = None
+    if "parent_id" in comment_data and comment_data["parent_id"] != "None":
+        parent = Comment.objects.filter(
+            id=int(str(comment_data["parent_id"]), 16)
+        ).first()
+
+    comment, _ = Comment.objects.update_or_create(
+        id=int(str(comment_data["_id"]), 16),
+        defaults={
+            "author": author,
+            "comment_thread": thread,
+            "parent": parent,
+            "course_id": comment_data["course_id"],
+            "body": comment_data["body"],
+            "anonymous": comment_data.get("anonymous", False),
+            "anonymous_to_peers": comment_data.get("anonymous_to_peers", False),
+            "endorsed": comment_data.get("endorsed", False),
+            "child_count": comment_data.get("child_count", 0),
+            "created_at": comment_data["created_at"],
+            "updated_at": comment_data["updated_at"],
+        },
+    )
+    create_votes(comment, comment_data.get("votes", {}))
+
+
+def create_votes(content: CommentThread | Comment, votes_data: dict[str, Any]) -> None:
+    """Create or update votes for a content."""
+    for vote_type in ["up", "down"]:
+        for user_id in votes_data.get(vote_type, []):
+            user = User.objects.get(pk=int(user_id))
+            UserVote.objects.update_or_create(
+                user=user,
+                content_type=content.content_type,
+                content_object_id=content.pk,
+                defaults={"vote": 1 if vote_type == "up" else -1},
+            )
+
+
+def migrate_subscriptions(db: Database[dict[str, Any]], content_id: str) -> None:
+    """Migrate subscriptions from mongo to mysql."""
+    subscriptions = db.subscriptions.find({"source_id": content_id})
+    for sub in subscriptions:
+        user = User.objects.get(id=int(sub["subscriber_id"]))
+        content_type = (
+            CommentThread if sub["source_type"] == "CommentThread" else Comment
+        )
+        content = content_type.objects.filter(id=int(str(content_id), 16)).first()
+
+        if content:
+            Subscription.objects.update_or_create(
+                subscriber=user,
+                source_content_type=content.content_type,
+                source_object_id=content.pk,
+                defaults={
+                    "created_at": sub.get("created_at", timezone.now()),
+                    "updated_at": sub.get("updated_at", timezone.now()),
+                },
+            )
+
+
+def migrate_read_states(db: Database[dict[str, Any]], course_id: str) -> None:
+    """Migrate read states from mongo to mysql."""
+    users = db.users.find({"course_stats.course_id": course_id})
+    for user_data in users:
+        try:
+            user = User.objects.get(id=int(user_data["_id"]))
+        except User.DoesNotExist:
+            continue
+
+        for read_state in user_data.get("read_states", []):
+            if read_state["course_id"] == course_id:
+                rs, _ = ReadState.objects.get_or_create(user=user, course_id=course_id)
+                for thread_id, timestamp in read_state.get(
+                    "last_read_times", {}
+                ).items():
+                    thread = CommentThread.objects.filter(id=thread_id).first()
+                    if thread:
+                        LastReadTime.objects.update_or_create(
+                            read_state=rs,
+                            comment_thread=thread,
+                            defaults={"timestamp": timestamp},
+                        )
+
+
+def delete_course_data(
+    db: Database[dict[str, Any]],
+    course_id: str,
+    dry_run: bool,
+    stdout: OutputWrapper,
+) -> None:
+    """Delete content (threads and comments)."""
+    contents = db.contents.find({"course_id": course_id})
+    for content in contents:
+        subscriptions = (
+            db.subscriptions.delete_many({"source_id": content["_id"]})
+            if not dry_run
+            else None
+        )
+    stdout.write(
+        f"Subscription documents to be deleted: {subscriptions.deleted_count if subscriptions else 'N/A (dry run)'}"
+    )
+
+    content_result = (
+        db.contents.delete_many({"course_id": course_id}) if not dry_run else None
+    )
+    stdout.write(
+        f"Content documents to be deleted: {content_result.deleted_count if content_result else 'N/A (dry run)'}"
+    )
+    user_ids = db.users.distinct("_id", {"course_stats.course_id": course_id})
+
+    for user_id in user_ids:
+        if not dry_run:
+            db.users.update_one(
+                {"_id": user_id},
+                {
+                    "$pull": {
+                        "course_stats": {"course_id": course_id},
+                        "read_states": {"course_id": course_id},
+                    }
+                },
+            )
+        stdout.write(f"Updated user data for user ID: {user_id}")
+
+    if not dry_run:
+        db.users.update_many(
+            {},
+            {
+                "$pull": {
+                    "course_stats": {"course_id": course_id},
+                    "read_states": {"course_id": course_id},
+                }
+            },
+        )
+    stdout.write("Cleaned up users collection")
+
+
+def log_deletion(
+    collection_name: str,
+    result: Collection[dict[str, Any]],
+    stdout: OutputWrapper,
+) -> None:
+    """Log the deletion of a collection."""
+    stdout.write(f"Deleted {result.deleted_count} documents from {collection_name}")
+
+
+def enable_mysql_backend_for_course(course_id: str) -> None:
+    """Enable MySQL backend waffle flag for a course."""
+    # pylint: disable=C0415,E0401
+    from opaque_keys.edx.locator import CourseKey  # type: ignore[import-not-found]
+    from openedx.core.djangoapps.waffle_utils import WaffleFlagCourseOverrideModel  # type: ignore[import-not-found]
+    from forum.toggles import ENABLE_MYSQL_BACKEND
+
+    course_key = CourseKey.from_string(course_id)
+    mysql_waffle_flag, _ = WaffleFlagCourseOverrideModel.objects.get_or_create(
+        course_id=course_key, waffle_flag=ENABLE_MYSQL_BACKEND.name
+    )
+    mysql_waffle_flag.enabled = True
+    mysql_waffle_flag.save()

--- a/forum/toggles.py
+++ b/forum/toggles.py
@@ -1,0 +1,18 @@
+"""Forum v2 feature toggles."""
+
+# pylint: disable=E0401
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag  # type: ignore[import-not-found]
+
+FORUM_V2_WAFFLE_FLAG_NAMESPACE = "forum_v2"
+
+
+# .. toggle_name: forum_v2.enable_mysql_backend
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to use the MySQL backend instead of Mongo backend.
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2025-12-05
+# .. toggle_target_removal_date: 2025-12-05
+ENABLE_MYSQL_BACKEND = CourseWaffleFlag(
+    f"{FORUM_V2_WAFFLE_FLAG_NAMESPACE}.enable_mysql_backend", __name__
+)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,6 +2,8 @@
 Init file for tests.
 """
 
+from typing import Any, Generator
+
 import logging
 import time
 
@@ -83,3 +85,13 @@ def patch_default_mongo_database() -> None:
 @pytest.fixture(autouse=True)
 def mock_elasticsearch_backend() -> None:
     """Overide teh mocked backend to use actual backend."""
+
+
+@pytest.fixture(autouse=True)
+def patched_get_backend(monkeypatch: pytest.MonkeyPatch) -> Generator[Any, Any, Any]:
+    """Return the patched get_backend function for Mongo backend."""
+    monkeypatch.setattr(
+        "forum.backend.is_mysql_backend_enabled",
+        lambda course_id: False,
+    )
+    yield

--- a/tests/test_management/test_commands/test_migration_commands.py
+++ b/tests/test_management/test_commands/test_migration_commands.py
@@ -1,0 +1,365 @@
+"""Test forum mongodb migration commands."""
+
+from io import StringIO
+from typing import Any
+
+import pytest
+from bson import ObjectId
+from django.core.management import call_command
+from django.contrib.auth.models import User  # pylint: disable=E5142
+from django.utils import timezone
+from pymongo.database import Database
+
+from forum.models import (
+    ForumUser,
+    CourseStat,
+    ReadState,
+    LastReadTime,
+    CommentThread,
+    Comment,
+    UserVote,
+    Subscription,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def patch_enable_mysql_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch enable_mysql_backend_for_course to just return."""
+    monkeypatch.setattr(
+        "forum.migration_helpers.enable_mysql_backend_for_course",
+        lambda course_id: None,
+    )
+
+
+def test_migrate_users(patched_mongodb: Database[Any]) -> None:
+    patched_mongodb.users.insert_one(
+        {
+            "_id": "1",
+            "username": "testuser",
+            "default_sort_key": "date",
+            "course_stats": [
+                {
+                    "course_id": "test_course",
+                    "active_flags": 1,
+                    "inactive_flags": 2,
+                    "threads": 3,
+                    "responses": 4,
+                    "replies": 5,
+                    "last_activity_at": timezone.now(),
+                }
+            ],
+            "read_states": [
+                {"course_id": "test_course", "last_read_times": {"1": timezone.now()}}
+            ],
+        }
+    )
+
+    call_command("forum_migrate_course_from_mongodb_to_mysql", "test_course")
+
+    user = User.objects.get(pk=1)
+    assert user.username == "testuser"
+    forum_user = ForumUser.objects.get(user=user)
+    assert forum_user.default_sort_key == "date"
+
+    course_stat = CourseStat.objects.get(user=user, course_id="test_course")
+    assert course_stat.active_flags == 1
+    assert course_stat.inactive_flags == 2
+    assert course_stat.threads == 3
+    assert course_stat.responses == 4
+    assert course_stat.replies == 5
+
+
+def test_migrate_content(patched_mongodb: Database[Any]) -> None:
+    patched_mongodb.users.insert_one(
+        {
+            "_id": "1",
+            "username": "testuser",
+            "default_sort_key": "date",
+            "course_stats": [
+                {
+                    "course_id": "test_course",
+                }
+            ],
+            "read_states": [
+                {
+                    "course_id": "test_course",
+                    "last_read_times": {"000000000000000000000001": timezone.now()},
+                }
+            ],
+        }
+    )
+    patched_mongodb.contents.insert_many(
+        [
+            {
+                "_id": ObjectId("000000000000000000000001"),
+                "_type": "CommentThread",
+                "author_id": "1",
+                "course_id": "test_course",
+                "title": "Test Thread",
+                "body": "Test body",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "votes": {"up": ["1"], "down": []},
+            },
+            {
+                "_id": ObjectId("000000000000000000000002"),
+                "_type": "Comment",
+                "author_id": "1",
+                "course_id": "test_course",
+                "body": "Test comment",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "comment_thread_id": ObjectId("000000000000000000000001"),
+                "votes": {"up": [], "down": ["1"]},
+            },
+        ]
+    )
+
+    user = User.objects.create(id=1, username="testuser")
+
+    call_command("forum_migrate_course_from_mongodb_to_mysql", "test_course")
+
+    thread = CommentThread.objects.get(
+        pk=int(str(ObjectId("000000000000000000000001")), 16)
+    )
+    assert thread.title == "Test Thread"
+    assert thread.body == "Test body"
+
+    comment = Comment.objects.get(pk=int(str(ObjectId("000000000000000000000002")), 16))
+    assert comment.body == "Test comment"
+    assert comment.comment_thread == thread
+
+    assert UserVote.objects.filter(content_object_id=thread.pk, vote=1).exists()
+    assert UserVote.objects.filter(content_object_id=comment.pk, vote=-1).exists()
+
+    read_state = ReadState.objects.get(user=user, course_id="test_course")
+    assert LastReadTime.objects.filter(read_state=read_state).exists()
+
+
+def test_migrate_subscriptions(patched_mongodb: Database[Any]) -> None:
+    patched_mongodb.contents.insert_many(
+        [
+            {
+                "_id": ObjectId("000000000000000000000001"),
+                "_type": "CommentThread",
+                "author_id": "1",
+                "course_id": "test_course",
+                "title": "Test Thread",
+                "body": "Test body",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "votes": {"up": ["1"], "down": []},
+            },
+            {
+                "_id": ObjectId("000000000000000000000002"),
+                "_type": "Comment",
+                "author_id": "1",
+                "course_id": "test_course",
+                "body": "Test comment",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "comment_thread_id": ObjectId("000000000000000000000001"),
+                "votes": {"up": [], "down": ["1"]},
+            },
+        ]
+    )
+    patched_mongodb.subscriptions.insert_one(
+        {
+            "subscriber_id": "1",
+            "source_id": ObjectId("000000000000000000000001"),
+            "source_type": "CommentThread",
+            "source": {"course_id": "test_course"},
+            "created_at": timezone.now(),
+            "updated_at": timezone.now(),
+        }
+    )
+
+    user = User.objects.create(pk=1, username="testuser")
+    thread = CommentThread.objects.create(
+        pk=int(str(ObjectId("000000000000000000000001")), 16),
+        author=user,
+        course_id="test_course",
+    )
+
+    call_command("forum_migrate_course_from_mongodb_to_mysql", "test_course")
+
+    assert Subscription.objects.filter(
+        subscriber=user, source_object_id=thread.pk
+    ).exists()
+
+
+def test_delete_course_data(patched_mongodb: Database[Any]) -> None:
+    patched_mongodb.users.insert_one(
+        {
+            "_id": "1",
+            "username": "testuser",
+            "default_sort_key": "date",
+            "course_stats": [
+                {
+                    "course_id": "test_course",
+                }
+            ],
+            "read_states": [
+                {
+                    "course_id": "test_course",
+                    "last_read_times": {"000000000000000000000001": timezone.now()},
+                }
+            ],
+        }
+    )
+    patched_mongodb.contents.insert_many(
+        [
+            {
+                "_id": ObjectId("000000000000000000000001"),
+                "_type": "CommentThread",
+                "author_id": "1",
+                "course_id": "test_course",
+                "title": "Test Thread",
+                "body": "Test body",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "votes": {"up": ["1"], "down": []},
+            },
+            {
+                "_id": ObjectId("000000000000000000000002"),
+                "_type": "Comment",
+                "author_id": "1",
+                "course_id": "test_course",
+                "body": "Test comment",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "comment_thread_id": ObjectId("000000000000000000000001"),
+                "votes": {"up": [], "down": ["1"]},
+            },
+        ]
+    )
+    patched_mongodb.subscriptions.insert_one(
+        {
+            "subscriber_id": "1",
+            "source_id": ObjectId("000000000000000000000001"),
+            "source_type": "CommentThread",
+            "source": {"course_id": "test_course"},
+            "created_at": timezone.now(),
+            "updated_at": timezone.now(),
+        }
+    )
+
+    out = StringIO()
+    call_command("forum_delete_course_from_mongodb", "test_course", stdout=out)
+
+    assert len(list(patched_mongodb.users.find())) == 1
+    user = patched_mongodb.users.find_one()
+    assert user
+    assert user["course_stats"] == []
+    assert user["read_states"] == []
+    assert len(list(patched_mongodb.contents.find())) == 0
+    assert len(list(patched_mongodb.subscriptions.find())) == 0
+
+    output = out.getvalue()
+    assert "Deleting data for course: test_course" in output
+    assert "Cleaned up users collection" in output
+    assert "Data deletion completed successfully" in output
+
+
+def test_delete_dry_run(patched_mongodb: Database[Any]) -> None:
+    """Call the command with dry-run option."""
+    patched_mongodb.users.insert_one(
+        {
+            "_id": "1",
+            "username": "testuser",
+            "default_sort_key": "date",
+            "course_stats": [
+                {
+                    "course_id": "test_course",
+                }
+            ],
+            "read_states": [
+                {
+                    "course_id": "test_course",
+                    "last_read_times": {"000000000000000000000001": timezone.now()},
+                }
+            ],
+        }
+    )
+    patched_mongodb.contents.insert_one(
+        {
+            "_id": ObjectId("000000000000000000000001"),
+            "_type": "CommentThread",
+            "author_id": "1",
+            "course_id": "test_course",
+            "title": "Test Thread",
+            "body": "Test body",
+            "created_at": timezone.now(),
+            "updated_at": timezone.now(),
+            "votes": {"up": ["1"], "down": []},
+        }
+    )
+    out = StringIO()
+    call_command(
+        "forum_delete_course_from_mongodb", "test_course", "--dry-run", stdout=out
+    )
+
+    output = out.getvalue()
+    assert "Performing dry run. No data will be deleted." in output
+    assert "Dry run completed. No data was deleted." in output
+    assert len(list(patched_mongodb.contents.find())) == 1
+
+
+def test_delete_all_courses(patched_mongodb: Database[Any]) -> None:
+    """Mock get_all_course_ids method."""
+    patched_mongodb.users.insert_one(
+        {
+            "_id": "1",
+            "username": "testuser",
+            "default_sort_key": "date",
+            "course_stats": [
+                {
+                    "course_id": "test_course_1",
+                },
+                {
+                    "course_id": "test_course_2",
+                },
+            ],
+            "read_states": [
+                {
+                    "course_id": "test_course_1",
+                    "last_read_times": {"000000000000000000000001": timezone.now()},
+                }
+            ],
+        }
+    )
+    patched_mongodb.contents.insert_many(
+        [
+            {
+                "_id": ObjectId("000000000000000000000001"),
+                "_type": "CommentThread",
+                "author_id": "1",
+                "course_id": "test_course_1",
+                "title": "Test Thread",
+                "body": "Test body",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "votes": {"up": ["1"], "down": []},
+            },
+            {
+                "_id": ObjectId("000000000000000000000002"),
+                "_type": "Comment",
+                "author_id": "1",
+                "course_id": "test_course_2",
+                "body": "Test comment",
+                "created_at": timezone.now(),
+                "updated_at": timezone.now(),
+                "comment_thread_id": ObjectId("000000000000000000000001"),
+                "votes": {"up": [], "down": ["1"]},
+            },
+        ]
+    )
+    out = StringIO()
+    call_command("forum_delete_course_from_mongodb", "all", stdout=out)
+
+    output = out.getvalue()
+    assert len(list(patched_mongodb.contents.find())) == 0
+    assert "Deleting data for course: test_course_1" in output
+    assert "Deleting data for course: test_course_2" in output

--- a/tests/test_views/test_commentables.py
+++ b/tests/test_views/test_commentables.py
@@ -1,21 +1,24 @@
 """Test commentables count api endpoint."""
 
+from typing import Any
+
 import random
 import uuid
 
 import pytest
 
-from forum.backend import get_backend
 from test_utils.client import APIClient
 
 pytestmark = pytest.mark.django_db
-backend = get_backend()()
 
 
-def test_get_commentables_counts_api(api_client: APIClient) -> None:
+def test_get_commentables_counts_api(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test retrieving counts of discussion and question threads for multiple commentables within a course.
     """
+    backend = patched_get_backend()
     username = "test_user"
     user_id = backend.find_or_create_user("1", username=username)
     course_id = "abcd"

--- a/tests/test_views/test_flags.py
+++ b/tests/test_views/test_flags.py
@@ -1,20 +1,20 @@
 """Test flags api endpoints."""
 
+from typing import Any
 import pytest
 
-from forum.backend import get_backend
 from test_utils.client import APIClient
 
 pytestmark = pytest.mark.django_db
-backend = get_backend()()
 
 
-def test_comment_thread_api(api_client: APIClient) -> None:
+def test_comment_thread_api(api_client: APIClient, patched_get_backend: Any) -> None:
     """
     Test the comment thread flag API.
 
     This test checks that a user can flag a comment thread for abuse and then unflag it.
     """
+    backend = patched_get_backend
     flag_user = backend.generate_id()
     author_user = backend.generate_id()
     backend.find_or_create_user(flag_user, flag_user)
@@ -61,12 +61,13 @@ def test_comment_thread_api(api_client: APIClient) -> None:
     assert comment["abuse_flaggers"] == []
 
 
-def test_comment_flag_api(api_client: APIClient) -> None:
+def test_comment_flag_api(api_client: APIClient, patched_get_backend: Any) -> None:
     """
     Test the comment flag API.
 
     This test checks that a user can flag a comment for abuse and then unflag it.
     """
+    backend = patched_get_backend
     flag_user = backend.generate_id()
     author_user = backend.generate_id()
     backend.find_or_create_user(flag_user, flag_user)
@@ -124,12 +125,15 @@ def test_comment_flag_api(api_client: APIClient) -> None:
     assert comment["abuse_flaggers"] == []
 
 
-def test_comment_flag_api_invalid_data(api_client: APIClient) -> None:
+def test_comment_flag_api_invalid_data(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test the comment flag API with invalid data.
 
     This test checks that the API returns a 400 error when the user or comment does not exist.
     """
+    backend = patched_get_backend
     user = backend.generate_id()
     backend.find_or_create_user(user)
     comment_id = backend.generate_id()
@@ -142,12 +146,15 @@ def test_comment_flag_api_invalid_data(api_client: APIClient) -> None:
     assert response.json() == {"error": "User / Comment doesn't exist"}
 
 
-def test_comment_flag_api_with_all_param(api_client: APIClient) -> None:
+def test_comment_flag_api_with_all_param(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test the comment flag API with the `all` parameter.
 
     This test checks that a user can flag a comment for abuse and then unflag it using all.
     """
+    backend = patched_get_backend
     flag_user = backend.generate_id()
     flag_user_2 = backend.generate_id()
     author_user = backend.generate_id()

--- a/tests/test_views/test_pins.py
+++ b/tests/test_views/test_pins.py
@@ -1,19 +1,21 @@
 """Test pin/unpin thread api endpoints."""
 
+from typing import Any
 import pytest
 
-from forum.backend import get_backend
 from test_utils.client import APIClient
 
 pytestmark = pytest.mark.django_db
-backend = get_backend()()
 
 
-def test_pin_and_unpin_thread_api(api_client: APIClient) -> None:
+def test_pin_and_unpin_thread_api(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test the pin/unpin thread API.
     This test checks that a user can pin/unpin a thread.
     """
+    backend = patched_get_backend
     user_id = "1"
 
     backend.find_or_create_user(user_id, username="user1")
@@ -64,11 +66,14 @@ def test_pin_and_unpin_thread_api(api_client: APIClient) -> None:
     assert thread["pinned"] is False
 
 
-def test_pin_unpin_thread_api_invalid_data(api_client: APIClient) -> None:
+def test_pin_unpin_thread_api_invalid_data(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test the invalid data for pin/unpin thread API.
     This test checks that if user/thread exists or not.
     """
+    backend = patched_get_backend
     user_id = "1"
     thread_id = backend.generate_id()
     backend.find_or_create_user(user_id, username="user1")

--- a/tests/test_views/test_subscriptions.py
+++ b/tests/test_views/test_subscriptions.py
@@ -1,18 +1,20 @@
 """Tests for subscription apis."""
 
+from typing import Any
 import pytest
 
-from forum.backend import get_backend
 from test_utils.client import APIClient
 
 pytestmark = pytest.mark.django_db
-backend = get_backend()()
 
 
-def test_get_subscribed_threads(api_client: APIClient) -> None:
+def test_get_subscribed_threads(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test getting subscribed threads for a user.
     """
+    backend = patched_get_backend
     user_id = "1"
     username = "user1"
     course_id = "demo_course"
@@ -38,10 +40,13 @@ def test_get_subscribed_threads(api_client: APIClient) -> None:
     assert threads[0]["id"] == comment_thread_id
 
 
-def test_get_subscribed_threads_with_filters(api_client: APIClient) -> None:
+def test_get_subscribed_threads_with_filters(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test getting subscribed threads for a user with filters.
     """
+    backend = patched_get_backend
     user_id = "1"
     username = "user1"
     course_id = "demo_course"
@@ -74,10 +79,11 @@ def test_get_subscribed_threads_with_filters(api_client: APIClient) -> None:
     assert threads[0]["id"] == comment_thread_id
 
 
-def test_subscribe_thread(api_client: APIClient) -> None:
+def test_subscribe_thread(api_client: APIClient, patched_get_backend: Any) -> None:
     """
     Test subscribing to a thread.
     """
+    backend = patched_get_backend
     user_id = "1"
     course_id = "demo_course"
     username = "user1"
@@ -105,10 +111,11 @@ def test_subscribe_thread(api_client: APIClient) -> None:
     assert subscription is not None
 
 
-def test_unsubscribe_thread(api_client: APIClient) -> None:
+def test_unsubscribe_thread(api_client: APIClient, patched_get_backend: Any) -> None:
     """
     Test unsubscribing from a thread.
     """
+    backend = patched_get_backend
     user_id = "1"
     course_id = "demo_course"
     username = "user1"
@@ -140,10 +147,13 @@ def test_unsubscribe_thread(api_client: APIClient) -> None:
     assert response.status_code == 400
 
 
-def test_get_subscribed_threads_with_pagination(api_client: APIClient) -> None:
+def test_get_subscribed_threads_with_pagination(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test getting subscribed threads for a user with pagination.
     """
+    backend = patched_get_backend
     user_id = "1"
     course_id = "demo_course"
     username = "user1"
@@ -211,10 +221,13 @@ def test_get_subscribed_threads_with_pagination(api_client: APIClient) -> None:
     ]
 
 
-def test_get_thread_subscriptions(api_client: APIClient) -> None:
+def test_get_thread_subscriptions(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test getting subscriptions of a thread.
     """
+    backend = patched_get_backend
     user_id = "1"
     course_id = "demo_course"
     username = "user1"
@@ -252,10 +265,13 @@ def test_get_thread_subscriptions(api_client: APIClient) -> None:
     assert len(subscriptions) == 0
 
 
-def test_get_thread_subscriptions_with_pagination(api_client: APIClient) -> None:
+def test_get_thread_subscriptions_with_pagination(
+    api_client: APIClient, patched_get_backend: Any
+) -> None:
     """
     Test getting subscriptions of a thread with pagination.
     """
+    backend = patched_get_backend
     user_id = "1"
     course_id = "demo_course"
     author_id = "10"

--- a/tests/test_views/test_votes.py
+++ b/tests/test_views/test_votes.py
@@ -4,15 +4,13 @@ from typing import Any
 
 import pytest
 
-from forum.backend import get_backend
 from test_utils.client import APIClient
 
 pytestmark = pytest.mark.django_db
-backend = get_backend()()
 
 
 @pytest.fixture(name="user")
-def get_user() -> dict[str, Any]:
+def get_user(patched_get_backend: Any) -> dict[str, Any]:
     """
     Fixture to create and return a test user.
 
@@ -21,13 +19,14 @@ def get_user() -> dict[str, Any]:
     Returns:
         dict[str, Any]: The created user, represented as a dictionary.
     """
+    backend = patched_get_backend
     user_id = "1"
     backend.find_or_create_user(user_id, username="testuser")
     return backend.get_user(user_id) or {}
 
 
 @pytest.fixture(name="thread")
-def get_thread(user: dict[str, Any]) -> dict[str, Any]:
+def get_thread(user: dict[str, Any], patched_get_backend: Any) -> dict[str, Any]:
     """
     Fixture to create and return a test thread.
 
@@ -40,6 +39,7 @@ def get_thread(user: dict[str, Any]) -> dict[str, Any]:
     Returns:
         dict[str, Any]: The created thread, represented as a dictionary.
     """
+    backend = patched_get_backend
     thread_id = backend.create_thread(
         {
             "title": "Test Thread",
@@ -56,7 +56,9 @@ def get_thread(user: dict[str, Any]) -> dict[str, Any]:
 
 
 @pytest.fixture(name="comment")
-def get_comment(user: dict[str, Any], thread: dict[str, Any]) -> dict[str, Any]:
+def get_comment(
+    user: dict[str, Any], thread: dict[str, Any], patched_get_backend: Any
+) -> dict[str, Any]:
     """
     Fixture to create and return a test comment.
 
@@ -70,6 +72,7 @@ def get_comment(user: dict[str, Any], thread: dict[str, Any]) -> dict[str, Any]:
     Returns:
         dict[str, Any]: The created comment, represented as a dictionary.
     """
+    backend = patched_get_backend
     comment_id = backend.create_comment(
         {
             "body": "This is a test comment.",
@@ -85,7 +88,10 @@ def get_comment(user: dict[str, Any], thread: dict[str, Any]) -> dict[str, Any]:
 
 
 def test_upvote_thread_api(
-    api_client: APIClient, user: dict[str, Any], thread: dict[str, Any]
+    api_client: APIClient,
+    user: dict[str, Any],
+    thread: dict[str, Any],
+    patched_get_backend: Any,
 ) -> None:
     """
     Test the API for upvoting a thread.
@@ -98,6 +104,7 @@ def test_upvote_thread_api(
         user (dict[str, Any]): The test user performing the upvote.
         thread (dict[str, Any]): The thread to be upvoted.
     """
+    backend = patched_get_backend
     user_id = user["_id"]
     thread_id = thread["_id"]
 
@@ -122,7 +129,10 @@ def test_upvote_thread_api(
 
 
 def test_vote_thread_api(
-    api_client: APIClient, user: dict[str, Any], thread: dict[str, Any]
+    api_client: APIClient,
+    user: dict[str, Any],
+    thread: dict[str, Any],
+    patched_get_backend: Any,
 ) -> None:
     """
     Test the API for upvoting, downvote, and again upvotes the same thread.
@@ -135,6 +145,7 @@ def test_vote_thread_api(
         user (dict[str, Any]): The test user performing the upvote.
         thread (dict[str, Any]): The thread to be upvoted.
     """
+    backend = patched_get_backend
     user_id = user["_id"]
     thread_id = thread["_id"]
 
@@ -175,7 +186,10 @@ def test_vote_thread_api(
 
 
 def test_downvote_thread_api(
-    api_client: APIClient, user: dict[str, Any], thread: dict[str, Any]
+    api_client: APIClient,
+    user: dict[str, Any],
+    thread: dict[str, Any],
+    patched_get_backend: Any,
 ) -> None:
     """
     Test the API for downvoting a thread.
@@ -188,6 +202,7 @@ def test_downvote_thread_api(
         user (dict[str, Any]): The test user performing the downvote.
         thread (dict[str, Any]): The thread to be downvoted.
     """
+    backend = patched_get_backend
     user_id = user["_id"]
     thread_id = thread["_id"]
 
@@ -208,7 +223,10 @@ def test_downvote_thread_api(
 
 
 def test_remove_vote_thread_api(
-    api_client: APIClient, user: dict[str, Any], thread: dict[str, Any]
+    api_client: APIClient,
+    user: dict[str, Any],
+    thread: dict[str, Any],
+    patched_get_backend: Any,
 ) -> None:
     """
     Test the API for removing a vote from a thread.
@@ -221,6 +239,7 @@ def test_remove_vote_thread_api(
         user (dict[str, Any]): The test user who performed the upvote.
         thread (dict[str, Any]): The thread from which the vote will be removed.
     """
+    backend = patched_get_backend
     user_id = user["_id"]
     thread_id = thread["_id"]
 
@@ -268,7 +287,10 @@ def test_remove_vote_thread_api(
 
 
 def test_upvote_comment_api(
-    api_client: APIClient, user: dict[str, Any], comment: dict[str, Any]
+    api_client: APIClient,
+    user: dict[str, Any],
+    comment: dict[str, Any],
+    patched_get_backend: Any,
 ) -> None:
     """
     Test the API for upvoting a comment.
@@ -281,6 +303,7 @@ def test_upvote_comment_api(
         user (dict[str, Any]): The test user performing the upvote.
         comment (dict[str, Any]): The comment to be upvoted.
     """
+    backend = patched_get_backend
     user_id = user["_id"]
     comment_id = comment["_id"]
 
@@ -301,7 +324,10 @@ def test_upvote_comment_api(
 
 
 def test_downvote_comment_api(
-    api_client: APIClient, user: dict[str, Any], comment: dict[str, Any]
+    api_client: APIClient,
+    user: dict[str, Any],
+    comment: dict[str, Any],
+    patched_get_backend: Any,
 ) -> None:
     """
     Test the API for downvoting a comment.
@@ -314,6 +340,7 @@ def test_downvote_comment_api(
         user (dict[str, Any]): The test user performing the downvote.
         comment (dict[str, Any]): The comment to be downvoted.
     """
+    backend = patched_get_backend
     user_id = user["_id"]
     comment_id = comment["_id"]
 
@@ -334,7 +361,10 @@ def test_downvote_comment_api(
 
 
 def test_remove_vote_comment_api(
-    api_client: APIClient, user: dict[str, Any], comment: dict[str, Any]
+    api_client: APIClient,
+    user: dict[str, Any],
+    comment: dict[str, Any],
+    patched_get_backend: Any,
 ) -> None:
     """
     Test the API for removing a vote from a comment.
@@ -347,6 +377,7 @@ def test_remove_vote_comment_api(
         user (dict[str, Any]): The test user who performed the upvote.
         comment (dict[str, Any]): The comment from which the vote will be removed.
     """
+    backend = patched_get_backend
     user_id = user["_id"]
     comment_id = comment["_id"]
 


### PR DESCRIPTION
feat: add migration command for mongo to mysql

- add migration command that copies courses data from mongodb to mysql models.
- add deletion command that deletes courses data from mongodb.
- add CourseWaffleFlag to retrieve correct backend for a course.
- enable waffle flag for course after migration is completed.
- fix patch_get_backend for `test_views/` tests.
- add unit tests for migration commands
- close #051
