### PR TITLE
fix: convert parent_id to ObjectId

### DIFF
--- a/forum/backends/mongodb/api.py
+++ b/forum/backends/mongodb/api.py
@@ -1479,6 +1479,8 @@ class MongoBackend(AbstractBackend):
         """Return comments from kwargs."""
         if "comment_thread_id" in kwargs:
             kwargs["comment_thread_id"] = ObjectId(kwargs["comment_thread_id"])
+        if parent_id := kwargs.get("parent_id"):
+            kwargs["parent_id"] = ObjectId(parent_id)
 
         return list(Comment().get_list(**kwargs))
 


### PR DESCRIPTION
- We were not able to get child comments as mongo was expecing parent_id as ObjectId to get list of child comments associated with the respective parent_id(ObjectId).
