### PR TITLE
fix: threads apis for mysql backend

### DIFF
--- a/forum/api/threads.py
+++ b/forum/api/threads.py
@@ -67,6 +67,7 @@ def prepare_thread_api_response(
     include_context: Optional[bool] = False,
     data_or_params: Optional[dict[str, Any]] = None,
     include_data_from_params: Optional[bool] = False,
+    course_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """Serialize thread data for the api response."""
     thread_data = get_thread_data(thread)
@@ -99,7 +100,7 @@ def prepare_thread_api_response(
                     if value := data_or_params.get(param):
                         context[param] = str_to_bool(value)
                 if user_id and backend.get_user(user_id):
-                    mark_thread_as_read(user_id, thread["_id"])
+                    mark_thread_as_read(user_id, thread["_id"], course_id=course_id)
 
     serializer = ThreadSerializer(
         data=thread_data,
@@ -150,6 +151,7 @@ def get_thread(
             True,
             params,
             True,
+            course_id=course_id,
         )
     except ValidationError as error:
         log.error(f"Validation error in get_thread: {error}")

--- a/forum/api/votes.py
+++ b/forum/api/votes.py
@@ -89,7 +89,7 @@ def update_thread_votes(
         raise ForumV2RequestError(vote_serializer.errors)
 
     try:
-        thread, user = _get_thread_and_user(thread_id, user_id)
+        thread, user = _get_thread_and_user(thread_id, user_id, course_id=course_id)
     except ValueError as error:
         raise ForumV2RequestError(str(error)) from error
 
@@ -120,7 +120,7 @@ def delete_thread_vote(
     """
     backend = get_backend(course_id)()
     try:
-        _, user = _get_thread_and_user(thread_id, user_id)
+        _, user = _get_thread_and_user(thread_id, user_id, course_id=course_id)
     except ValueError as error:
         raise ForumV2RequestError(str(error)) from error
 

--- a/forum/migration_helpers.py
+++ b/forum/migration_helpers.py
@@ -95,6 +95,8 @@ def create_or_update_thread(thread_data: dict[str, Any]) -> None:
             pinned=thread_data.get("pinned"),
             created_at=make_aware(thread_data["created_at"]),
             updated_at=make_aware(thread_data["updated_at"]),
+            last_activity_at=make_aware(thread_data["last_activity_at"]),
+            commentable_id=thread_data.get("commentable_id"),
         )
         mongo_content.content_object_id = thread.pk
         mongo_content.content_type = thread.content_type

--- a/tests/test_management/test_commands/test_migration_commands.py
+++ b/tests/test_management/test_commands/test_migration_commands.py
@@ -123,6 +123,7 @@ def test_migrate_content(patched_mongodb: Database[Any]) -> None:
                 "votes": {"up": ["1"], "down": []},
                 "abuse_flaggers": ["1", "2"],
                 "historical_abuse_flaggers": ["1", "2"],
+                "last_activity_at": timezone.now(),
             },
             {
                 "_id": comment_id,
@@ -177,6 +178,7 @@ def test_migrate_subscriptions(patched_mongodb: Database[Any]) -> None:
                 "body": "Test body",
                 "created_at": timezone.now(),
                 "updated_at": timezone.now(),
+                "last_activity_at": timezone.now(),
                 "votes": {"up": ["1"], "down": []},
                 "abuse_flaggers": [
                     "1",


### PR DESCRIPTION
fix: This PR fixes get threads apis and thread votes api as migration command weren't storing last_activity_at and commentable_id

